### PR TITLE
Desugar abbreviation for multiple anonymous parameters, results and locals

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -309,43 +309,24 @@ module Wasminna
     def read_lists(starting_with:, desugared:)
       [].tap do |results|
         while can_read_list?(starting_with:)
-          result = read_list { yield }
-          if desugared
-            results << result
-          else
-            results.concat(result)
-          end
+          results << read_list { yield }
         end
       end
     end
 
     def parse_parameter(desugared:)
       read => 'param'
-      if desugared
-        if peek in ID_REGEXP
-          read => ID_REGEXP => name
-        end
-        read => type
-
-        [name, type]
-      else
-        if peek in ID_REGEXP
-          read => ID_REGEXP => name
-          read => type
-          [[name, type]]
-        else
-          repeatedly { read }.map { |type| [nil, type] }
-        end
+      if peek in ID_REGEXP
+        read => ID_REGEXP => name
       end
+      read => type
+
+      [name, type]
     end
 
     def parse_result(desugared:)
       read => 'result'
-      if desugared
-        read
-      else
-        repeatedly { read }
-      end
+      read
     end
 
     def parse_local

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -305,9 +305,7 @@ module Wasminna
     def parse_locals
       [].tap do |results|
         while can_read_list?(starting_with: 'local')
-          read_list do
-            results << parse_local
-          end
+          results << read_list { parse_local }
         end
       end
     end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -298,9 +298,7 @@ module Wasminna
       if desugared
         [].tap do |results|
           while can_read_list?(starting_with: 'param')
-            read_list do
-              results << parse_parameter(desugared:)
-            end
+            results << read_list { parse_parameter(desugared:) }
           end
         end
       else
@@ -312,9 +310,7 @@ module Wasminna
       if desugared
         [].tap do |results|
           while can_read_list?(starting_with: 'result')
-            read_list do
-              results << parse_result(desugared:)
-            end
+            results << read_list { parse_result(desugared:) }
           end
         end
       else

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -306,7 +306,7 @@ module Wasminna
       [].tap do |results|
         while can_read_list?(starting_with: 'local')
           read_list do
-            results.concat(parse_local)
+            results << parse_local
           end
         end
       end
@@ -345,7 +345,7 @@ module Wasminna
       end
       read => type
 
-      [[name, type]]
+      [name, type]
     end
 
     def parse_function

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -295,42 +295,25 @@ module Wasminna
     end
 
     def parse_parameters(desugared:)
-      if desugared
-        [].tap do |results|
-          while can_read_list?(starting_with: 'param')
-            results << read_list { parse_parameter(desugared:) }
-          end
-        end
-      else
-        read_lists(starting_with: 'param') { parse_parameter(desugared:) }
-      end
+      read_lists(starting_with: 'param', desugared:) { parse_parameter(desugared:) }
     end
 
     def parse_results(desugared:)
-      if desugared
-        [].tap do |results|
-          while can_read_list?(starting_with: 'result')
-            results << read_list { parse_result(desugared:) }
-          end
-        end
-      else
-        read_lists(starting_with: 'result') { parse_result(desugared:) }
-      end
+      read_lists(starting_with: 'result', desugared:) { parse_result(desugared:) }
     end
 
     def parse_locals
-      [].tap do |results|
-        while can_read_list?(starting_with: 'local')
-          results << read_list { parse_local }
-        end
-      end
+      read_lists(starting_with: 'local', desugared: true) { parse_local }
     end
 
-    def read_lists(starting_with:)
+    def read_lists(starting_with:, desugared:)
       [].tap do |results|
         while can_read_list?(starting_with:)
-          read_list do
-            results.concat(yield)
+          result = read_list { yield }
+          if desugared
+            results << result
+          else
+            results.concat(result)
           end
         end
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -295,15 +295,18 @@ module Wasminna
     end
 
     def parse_parameters
-      read_lists(starting_with: 'param') { parse_parameter }
+      read_lists(starting_with: 'param') { parse_declaration(kind: 'param') }
     end
 
     def parse_results
-      read_lists(starting_with: 'result') { parse_result }
+      read_lists(starting_with: 'result') do
+        parse_declaration(kind: 'result') => [nil, type]
+        type
+      end
     end
 
     def parse_locals
-      read_lists(starting_with: 'local') { parse_local }
+      read_lists(starting_with: 'local') { parse_declaration(kind: 'local') }
     end
 
     def read_lists(starting_with:)
@@ -314,23 +317,8 @@ module Wasminna
       end
     end
 
-    def parse_parameter
-      read => 'param'
-      if peek in ID_REGEXP
-        read => ID_REGEXP => name
-      end
-      read => type
-
-      [name, type]
-    end
-
-    def parse_result
-      read => 'result'
-      read
-    end
-
-    def parse_local
-      read => 'local'
+    def parse_declaration(kind:)
+      read => ^kind
       if peek in ID_REGEXP
         read => ID_REGEXP => name
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -589,7 +589,7 @@ module Wasminna
 
           case kind
           in 'func'
-            parse_typeuse(desugared: false) => [type_index, _]
+            parse_typeuse(desugared: true) => [type_index, _]
             [:func, type_index]
           in 'global'
             [:global, parse_globaltype]

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -322,18 +322,31 @@ module Wasminna
 
     def parse_parameter(desugared:)
       read => 'param'
-      if peek in ID_REGEXP
-        read => ID_REGEXP => name
+      if desugared
+        if peek in ID_REGEXP
+          read => ID_REGEXP => name
+        end
         read => type
+
         [[name, type]]
       else
-        repeatedly { read }.map { |type| [nil, type] }
+        if peek in ID_REGEXP
+          read => ID_REGEXP => name
+          read => type
+          [[name, type]]
+        else
+          repeatedly { read }.map { |type| [nil, type] }
+        end
       end
     end
 
     def parse_result(desugared:)
       read => 'result'
-      repeatedly { read }
+      if desugared
+        [read]
+      else
+        repeatedly { read }
+      end
     end
 
     def parse_local

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -336,11 +336,10 @@ module Wasminna
       read => 'local'
       if peek in ID_REGEXP
         read => ID_REGEXP => name
-        read => type
-        [[name, type]]
-      else
-        repeatedly { read }.map { |type| [nil, type] }
       end
+      read => type
+
+      [[name, type]]
     end
 
     def parse_function

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -299,7 +299,7 @@ module Wasminna
         [].tap do |results|
           while can_read_list?(starting_with: 'param')
             read_list do
-              results.concat(parse_parameter(desugared:))
+              results << parse_parameter(desugared:)
             end
           end
         end
@@ -313,7 +313,7 @@ module Wasminna
         [].tap do |results|
           while can_read_list?(starting_with: 'result')
             read_list do
-              results.concat(parse_result(desugared:))
+              results << parse_result(desugared:)
             end
           end
         end
@@ -348,7 +348,7 @@ module Wasminna
         end
         read => type
 
-        [[name, type]]
+        [name, type]
       else
         if peek in ID_REGEXP
           read => ID_REGEXP => name
@@ -363,7 +363,7 @@ module Wasminna
     def parse_result(desugared:)
       read => 'result'
       if desugared
-        [read]
+        read
       else
         repeatedly { read }
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -303,7 +303,13 @@ module Wasminna
     end
 
     def parse_locals
-      read_lists(starting_with: 'local') { parse_local }
+      [].tap do |results|
+        while can_read_list?(starting_with: 'local')
+          read_list do
+            results.concat(parse_local)
+          end
+        end
+      end
     end
 
     def read_lists(starting_with:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -295,7 +295,7 @@ module Wasminna
     end
 
     def parse_parameters
-      read_lists(starting_with: 'param') { parse_parameter_or_local }
+      read_lists(starting_with: 'param') { parse_parameter }
     end
 
     def parse_results
@@ -303,7 +303,7 @@ module Wasminna
     end
 
     def parse_locals
-      read_lists(starting_with: 'local') { parse_parameter_or_local }
+      read_lists(starting_with: 'local') { parse_local }
     end
 
     def read_lists(starting_with:)
@@ -316,8 +316,8 @@ module Wasminna
       end
     end
 
-    def parse_parameter_or_local
-      read => 'param' | 'local'
+    def parse_parameter
+      read => 'param'
       if peek in ID_REGEXP
         read => ID_REGEXP => name
         read => type
@@ -330,6 +330,17 @@ module Wasminna
     def parse_result
       read => 'result'
       repeatedly { read }
+    end
+
+    def parse_local
+      read => 'local'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => name
+        read => type
+        [[name, type]]
+      else
+        repeatedly { read }.map { |type| [nil, type] }
+      end
     end
 
     def parse_function

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -295,11 +295,31 @@ module Wasminna
     end
 
     def parse_parameters(desugared:)
-      read_lists(starting_with: 'param') { parse_parameter(desugared:) }
+      if desugared
+        [].tap do |results|
+          while can_read_list?(starting_with: 'param')
+            read_list do
+              results.concat(parse_parameter(desugared:))
+            end
+          end
+        end
+      else
+        read_lists(starting_with: 'param') { parse_parameter(desugared:) }
+      end
     end
 
     def parse_results(desugared:)
-      read_lists(starting_with: 'result') { parse_result(desugared:) }
+      if desugared
+        [].tap do |results|
+          while can_read_list?(starting_with: 'result')
+            read_list do
+              results.concat(parse_result(desugared:))
+            end
+          end
+        end
+      else
+        read_lists(starting_with: 'result') { parse_result(desugared:) }
+      end
     end
 
     def parse_locals

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -881,7 +881,7 @@ module Wasminna
     def parse_blocktype
       type_index, parameter_names, updated_typedefs =
         with_context(context) do
-          parse_typeuse(desugared: false) => [type_index, parameter_names]
+          parse_typeuse(desugared: true) => [type_index, parameter_names]
           [type_index, parameter_names, context.typedefs]
         end
       raise unless parameter_names.all?(&:nil?)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -295,24 +295,24 @@ module Wasminna
     end
 
     def parse_parameters
-      read_lists(starting_with: 'param') { parse_declaration(kind: 'param') }
+      parse_declarations(kind: 'param')
     end
 
     def parse_results
-      read_lists(starting_with: 'result') do
-        parse_declaration(kind: 'result') => [nil, type]
+      parse_declarations(kind: 'result').map do |result|
+        result => [nil, type]
         type
       end
     end
 
     def parse_locals
-      read_lists(starting_with: 'local') { parse_declaration(kind: 'local') }
+      parse_declarations(kind: 'local')
     end
 
-    def read_lists(starting_with:)
+    def parse_declarations(kind:)
       [].tap do |results|
-        while can_read_list?(starting_with:)
-          results << read_list { yield }
+        while can_read_list?(starting_with: kind)
+          results << read_list { parse_declaration(kind:) }
         end
       end
     end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -135,8 +135,8 @@ module Wasminna
             end
             type =
               read_list(starting_with: 'func') do
-                _, parameters = unzip_pairs(parse_parameters(desugared: false))
-                results = parse_results(desugared: false)
+                _, parameters = unzip_pairs(parse_parameters(desugared: true))
+                results = parse_results(desugared: true)
                 Type.new(parameters:, results:)
               end
             Context.new(types: [name], typedefs: [type])
@@ -287,8 +287,8 @@ module Wasminna
 
       read_list do
         read => 'func'
-        _, parameters = unzip_pairs(parse_parameters(desugared: false))
-        results = parse_results(desugared: false)
+        _, parameters = unzip_pairs(parse_parameters(desugared: true))
+        results = parse_results(desugared: true)
 
         Type.new(parameters:, results:)
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -90,7 +90,15 @@ module Wasminna
 
     def process_typeuse(definition)
       [].tap do |typeuse|
-        while definition in [['type' | 'param' | 'result', *], *]
+        if definition in [['type', *], *]
+          typeuse.push(definition.shift)
+        end
+
+        while definition in [['param', *], *]
+          typeuse.push(definition.shift)
+        end
+
+        while definition in [['result', *], *]
           typeuse.push(definition.shift)
         end
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -42,7 +42,7 @@ module Wasminna
 
     def process_module(mod)
       case mod
-      in ['module', String => id, *fields]
+      in ['module', ID_REGEXP => id, *fields]
         ['module', id, *fields.flat_map { process_field(_1) }]
       in ['module', *fields]
         ['module', *fields.flat_map { process_field(_1) }]
@@ -51,11 +51,11 @@ module Wasminna
 
     def process_field(field)
       case field
-      in ['func' | 'table' | 'memory' | 'global' => kind, String => id, ['import', module_name, name], *description]
+      in ['func' | 'table' | 'memory' | 'global' => kind, ID_REGEXP => id, ['import', module_name, name], *description]
         [['import', module_name, name, [kind, id, *description]]]
       in ['func' | 'table' | 'memory' | 'global' => kind, ['import', module_name, name], *description]
         [['import', module_name, name, [kind, *description]]]
-      in ['func' | 'table' | 'memory' | 'global' => kind, String => id, ['export', name], *rest]
+      in ['func' | 'table' | 'memory' | 'global' => kind, ID_REGEXP => id, ['export', name], *rest]
         [
           ['export', name, [kind, id]],
           *process_field([kind, id, *rest])
@@ -77,7 +77,7 @@ module Wasminna
 
     def process_function(function)
       case function
-      in ['func', String => id, *definition]
+      in ['func', ID_REGEXP => id, *definition]
         typeuse = process_typeuse(definition)
         locals = process_locals(definition)
         ['func', id, *typeuse, *locals, *definition]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -66,8 +66,39 @@ module Wasminna
           ['export', name, [kind, id]],
           *process_field([kind, id, *rest])
         ]
+      in ['func', *]
+        [process_function(field)]
       else
         [field]
+      end
+    end
+
+    def process_function(function)
+      case function
+      in ['func', String => id, *definition]
+        typeuse = process_typeuse(definition)
+        locals = process_locals(definition)
+        ['func', id, *typeuse, *locals, *definition]
+      in ['func', *definition]
+        typeuse = process_typeuse(definition)
+        locals = process_locals(definition)
+        ['func', *typeuse, *locals, *definition]
+      end
+    end
+
+    def process_typeuse(definition)
+      [].tap do |typeuse|
+        while definition in [['type' | 'param' | 'result', *], *]
+          typeuse.push(definition.shift)
+        end
+      end
+    end
+
+    def process_locals(definition)
+      [].tap do |locals|
+        while definition in [['local', *], *]
+          locals.push(definition.shift)
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -25,6 +25,8 @@ module Wasminna
 
     private
 
+    ID_REGEXP = %r{\A\$}
+
     attr_accessor :fresh_id
 
     def process_command(command)
@@ -97,7 +99,15 @@ module Wasminna
     def process_locals(definition)
       [].tap do |locals|
         while definition in [['local', *], *]
-          locals.push(definition.shift)
+          local = definition.shift
+          case local
+          in ['local', ID_REGEXP => id, type]
+            locals.push(local)
+          in ['local', *types]
+            types.each do |type|
+              locals.push(['local', type])
+            end
+          end
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -99,25 +99,35 @@ module Wasminna
         if definition in [['type', *], *]
           typeuse.push(definition.shift)
         end
+        typeuse.concat(process_parameters(definition))
+        typeuse.concat(process_results(definition))
+      end
+    end
 
+    def process_parameters(definition)
+      [].tap do |parameters|
         while definition in [['param', *], *]
           param = definition.shift
           case param
           in ['param', ID_REGEXP => id, type]
-            typeuse.push(param)
+            parameters.push(param)
           in ['param', *types]
             types.each do |type|
-              typeuse.push(['param', type])
+              parameters.push(['param', type])
             end
           end
         end
+      end
+    end
 
+    def process_results(definition)
+      [].tap do |results|
         while definition in [['result', *], *]
           result = definition.shift
           case result
           in ['result', *types]
             types.each do |type|
-              typeuse.push(['result', type])
+              results.push(['result', type])
             end
           end
         end
@@ -166,28 +176,8 @@ module Wasminna
       [].tap do |functype|
         definition.shift => 'func'
         functype.push('func')
-
-        while definition in [['param', *], *]
-          param = definition.shift
-          case param
-          in ['param', ID_REGEXP => id, type]
-            functype.push(param)
-          in ['param', *types]
-            types.each do |type|
-              functype.push(['param', type])
-            end
-          end
-        end
-
-        while definition in [['result', *], *]
-          result = definition.shift
-          case result
-          in ['result', *types]
-            types.each do |type|
-              functype.push(['result', type])
-            end
-          end
-        end
+        functype.concat(process_parameters(definition))
+        functype.concat(process_results(definition))
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -95,13 +95,13 @@ module Wasminna
     end
 
     def process_typeuse(definition)
-      [].tap do |typeuse|
-        if definition in [['type', *], *]
-          typeuse.push(definition.shift)
-        end
-        typeuse.concat(process_parameters(definition))
-        typeuse.concat(process_results(definition))
+      if definition in [['type', *], *]
+        type = [definition.shift]
       end
+      parameters = process_parameters(definition)
+      results = process_results(definition)
+
+      [*type, *parameters, *results]
     end
 
     def process_parameters(definition)
@@ -154,12 +154,11 @@ module Wasminna
     end
 
     def process_functype(definition)
-      [].tap do |functype|
-        definition.shift => 'func'
-        functype.push('func')
-        functype.concat(process_parameters(definition))
-        functype.concat(process_results(definition))
-      end
+      definition.shift => 'func'
+      parameters = process_parameters(definition)
+      results = process_results(definition)
+
+      ['func', *parameters, *results]
     end
 
     def process_import(import)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -143,6 +143,8 @@ module Wasminna
     def process_instructions(instructions)
       instructions.flat_map do |instruction|
         case instruction
+        in ['param' | 'result' => kind, *types]
+          types.map { |type| [kind, type] }
         in [*]
           [process_instructions(instruction)]
         else

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -84,11 +84,13 @@ module Wasminna
       in ['func', ID_REGEXP => id, *definition]
         typeuse = process_typeuse(definition)
         locals = process_locals(definition)
-        ['func', id, *typeuse, *locals, *definition]
+        body = process_instructions(definition)
+        ['func', id, *typeuse, *locals, *body]
       in ['func', *definition]
         typeuse = process_typeuse(definition)
         locals = process_locals(definition)
-        ['func', *typeuse, *locals, *definition]
+        body = process_instructions(definition)
+        ['func', *typeuse, *locals, *body]
       end
     end
 
@@ -134,6 +136,17 @@ module Wasminna
               locals.push(['local', type])
             end
           end
+        end
+      end
+    end
+
+    def process_instructions(instructions)
+      instructions.flat_map do |instruction|
+        case instruction
+        in [*]
+          [process_instructions(instruction)]
+        else
+          [instruction]
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -70,6 +70,8 @@ module Wasminna
         ]
       in ['func', *]
         [process_function(field)]
+      in ['type', *]
+        [process_type(field)]
       else
         [field]
       end
@@ -130,6 +132,30 @@ module Wasminna
               locals.push(['local', type])
             end
           end
+        end
+      end
+    end
+
+    def process_type(type)
+      case type
+      in ['type', ID_REGEXP => id, definition]
+        ['type', id, process_functype(definition)]
+      in ['type', definition]
+        ['type', process_functype(definition)]
+      end
+    end
+
+    def process_functype(definition)
+      [].tap do |functype|
+        definition.shift => 'func'
+        functype.push('func')
+
+        while definition in [['param', *], *]
+          functype.push(definition.shift)
+        end
+
+        while definition in [['result', *], *]
+          functype.push(definition.shift)
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -151,11 +151,25 @@ module Wasminna
         functype.push('func')
 
         while definition in [['param', *], *]
-          functype.push(definition.shift)
+          param = definition.shift
+          case param
+          in ['param', ID_REGEXP => id, type]
+            functype.push(param)
+          in ['param', *types]
+            types.each do |type|
+              functype.push(['param', type])
+            end
+          end
         end
 
         while definition in [['result', *], *]
-          functype.push(definition.shift)
+          result = definition.shift
+          case result
+          in ['result', *types]
+            types.each do |type|
+              functype.push(['result', type])
+            end
+          end
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -95,11 +95,25 @@ module Wasminna
         end
 
         while definition in [['param', *], *]
-          typeuse.push(definition.shift)
+          param = definition.shift
+          case param
+          in ['param', ID_REGEXP => id, type]
+            typeuse.push(param)
+          in ['param', *types]
+            types.each do |type|
+              typeuse.push(['param', type])
+            end
+          end
         end
 
         while definition in [['result', *], *]
-          typeuse.push(definition.shift)
+          result = definition.shift
+          case result
+          in ['result', *types]
+            types.each do |type|
+              typeuse.push(['result', type])
+            end
+          end
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -72,6 +72,8 @@ module Wasminna
         [process_function(field)]
       in ['type', *]
         [process_type(field)]
+      in ['import', *]
+        [process_import(field)]
       else
         [field]
       end
@@ -171,6 +173,22 @@ module Wasminna
             end
           end
         end
+      end
+    end
+
+    def process_import(import)
+      import => ['import', module_name, name, descriptor]
+      ['import', module_name, name, process_import_descriptor(descriptor)]
+    end
+
+    def process_import_descriptor(descriptor)
+      case descriptor
+      in ['func', ID_REGEXP => id, *typeuse]
+        ['func', id, *typeuse]
+      in ['func', *typeuse]
+        ['func', *typeuse]
+      else
+        descriptor
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -184,9 +184,9 @@ module Wasminna
     def process_import_descriptor(descriptor)
       case descriptor
       in ['func', ID_REGEXP => id, *typeuse]
-        ['func', id, *typeuse]
+        ['func', id, *process_typeuse(typeuse)]
       in ['func', *typeuse]
-        ['func', *typeuse]
+        ['func', *process_typeuse(typeuse)]
       else
         descriptor
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -105,47 +105,28 @@ module Wasminna
     end
 
     def process_parameters(definition)
-      [].tap do |parameters|
-        while definition in [['param', *], *]
-          param = definition.shift
-          case param
-          in ['param', ID_REGEXP => id, type]
-            parameters.push(param)
-          in ['param', *types]
-            types.each do |type|
-              parameters.push(['param', type])
-            end
-          end
-        end
-      end
+      expand_anonymous_declarations(definition, kind: 'param')
     end
 
     def process_results(definition)
-      [].tap do |results|
-        while definition in [['result', *], *]
-          result = definition.shift
-          case result
-          in ['result', *types]
-            types.each do |type|
-              results.push(['result', type])
-            end
-          end
-        end
-      end
+      expand_anonymous_declarations(definition, kind: 'result')
     end
 
     def process_locals(definition)
-      [].tap do |locals|
-        while definition in [['local', *], *]
-          local = definition.shift
-          case local
-          in ['local', ID_REGEXP => id, type]
-            locals.push(local)
-          in ['local', *types]
-            types.each do |type|
-              locals.push(['local', type])
+      expand_anonymous_declarations(definition, kind: 'local')
+    end
+
+    def expand_anonymous_declarations(s_expression, kind:)
+      [].tap do |declarations|
+        while s_expression in [[^kind, *], *]
+          expanded_declarations =
+            case s_expression.shift
+            in [^kind, ID_REGEXP, _] => declaration
+              [declaration]
+            in [^kind, *types]
+              types.map { |type| [kind, type] }
             end
-          end
+          declarations.concat(expanded_declarations)
         end
       end
     end

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -244,4 +244,21 @@ else
   raise actual.inspect unless actual == expected
 end
 
+input = [
+  ['module',
+    ['import', 'a', 'b', ['func', %w[param i32 i64], %w[result f32 f64]]]
+  ]
+]
+expected = [
+  ['module',
+    ['import', 'a', 'b', ['func', %w[param i32], %w[param i64], %w[result f32], %w[result f64]]]
+  ]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
 puts

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -227,4 +227,21 @@ else
   raise actual.inspect unless actual == expected
 end
 
+input = [
+  ['module',
+    ['type', ['func', %w[param i32 i64], %w[result f32 f64]]]
+  ]
+]
+expected = [
+  ['module',
+    ['type', ['func', %w[param i32], %w[param i64], %w[result f32], %w[result f64]]]
+  ]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
 puts

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -210,4 +210,21 @@ else
   raise actual.inspect unless actual == expected
 end
 
+input = [
+  ['module',
+   ['func', %w[param i32 i64], %w[result i64 i32], %w[i64.const 1], %w[i32.const 2]]
+  ]
+]
+expected = [
+  ['module',
+   ['func', %w[param i32], %w[param i64], %w[result i64], %w[result i32], %w[i64.const 1], %w[i32.const 2]]
+  ]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
 puts

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -261,4 +261,56 @@ else
   raise actual.inspect unless actual == expected
 end
 
+input = [
+  ['module',
+    ['func',
+      ['block', %w[param i32 i32], %w[result i32 i32],
+        %w[i32 add], %w[i32.const 1]
+      ]
+    ]
+  ]
+]
+expected = [
+  ['module',
+    ['func',
+      ['block', %w[param i32], %w[param i32], %w[result i32], %w[result i32],
+        %w[i32 add], %w[i32.const 1]
+      ]
+    ]
+  ]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
+input = [
+  ['module',
+    ['func',
+      ['call_indirect',
+        %w[param i64], %w[param], %w[param f64 i32 i64],
+        %w[result f32 f64], %w[result i32]
+      ]
+    ]
+  ]
+]
+expected = [
+  ['module',
+    ['func',
+      ['call_indirect',
+        %w[param i64], %w[param f64], %w[param i32], %w[param i64],
+        %w[result f32], %w[result f64], %w[result i32]
+      ]
+    ]
+  ]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
 puts

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -193,4 +193,21 @@ else
   raise actual.inspect unless actual == expected
 end
 
+input = [
+  ['module',
+    ['func', %w[result i32], %w[local i32 f64 funcref], ['return', %w[i32.const 0x0bAdD00D]]]
+  ]
+]
+expected = [
+  ['module',
+    ['func', %w[result i32], %w[local i32], %w[local f64], %w[local funcref], ['return', %w[i32.const 0x0bAdD00D]]]
+  ]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
 puts


### PR DESCRIPTION
The WebAssembly [text format](https://webassembly.github.io/spec/core/text/) (`.wat`) includes many syntactic abbreviations which are explicitly supported by our `.wat` parser, complicating its implementation.

We previously [introduced](https://github.com/tomstuart/wasminna/commit/a65d7beb1d9de55f69363a386f5cd57fdff2d8ea) an S-expression preprocessor and [used it](https://github.com/tomstuart/wasminna/compare/439b6e7795d63c57a5c94a2824bba3b3193f9a2d...1371bd16f52694ec6e44ba30851f411355d3374d) to desugar [`import`](https://webassembly.github.io/spec/core/text/modules.html#id1) and [`export`](https://webassembly.github.io/spec/core/text/modules.html#id6) abbreviations so the parser doesn’t need to handle them any more. Now that the preprocessor is hooked up, we have the opportunity to move more of the abbreviation handling into it and further simplify the parser and AST. This simplification should also make it easier to introduce a similar parser for the [binary format](https://webassembly.github.io/spec/core/binary/) (`.wasm`) in future.

[`param`, `result`](https://webassembly.github.io/spec/core/text/types.html#abbreviations) and [`local`](https://webassembly.github.io/spec/core/text/modules.html#text-func-abbrev) all support an abbreviation for multiple anonymous occurrences. For example, this function definition…

```
(func
  (param i32) (param i64)
  (result f32) (result f64)
  (local funcref) (local externref)
  …
)
```

…may be written more concisely as:

```
(func
  (param i32 i64)
  (result f32 f64)
  (local funcref externref)
  …
)
```

This PR uses the preprocessor to desugar the multiple anonymous occurrences abbreviation so that the `.wat` parser only has to handle unabbreviated `param`, `result` and `local` syntax.

Note that `param` and `result` can appear as part of a [type use](https://webassembly.github.io/spec/core/text/modules.html#type-uses) inside an instruction; to keep the implementation simple, we intentionally avoid desugaring instructions outside of function bodies (see b23df4953b848d614828451009ba9fa8468f3848 for details) since [validation](https://webassembly.github.io/spec/core/valid/instructions.html#valid-constant) prevents those from containing this specific abbreviation anyway. We’ll probably need to desugar instructions in these places eventually for other reasons (e.g. [unfolding](https://webassembly.github.io/spec/core/text/instructions.html#text-foldedinstr)) but that’s a problem for another day.