### PR TITLE
Store current S-expression in preprocessor state and destructively consume it

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -7,6 +7,7 @@ module Wasminna
   class ASTParser
     include AST
     include Helpers::Mask
+    include Helpers::ReadFromSExpression
 
     def parse_script(s_expression)
       read_list(from: s_expression) do
@@ -658,18 +659,6 @@ module Wasminna
       end
     end
 
-    def read_list(from: read, starting_with: nil)
-      raise "not a list: #{from.inspect}" unless from in [*]
-      previous_s_expression, self.s_expression = self.s_expression, from
-
-      read => ^starting_with unless starting_with.nil?
-
-      yield.tap do
-        raise unless finished?
-        self.s_expression = previous_s_expression
-      end
-    end
-
     def parse_instruction
       case peek
       in NUMERIC_OPCODE_REGEXP
@@ -1102,36 +1091,6 @@ module Wasminna
           unzipped
         end
       end
-    end
-
-    def repeatedly(**kwargs)
-      terminator = kwargs[:until]
-
-      [].tap do |results|
-        until finished? || (!terminator.nil? && peek in ^terminator)
-          results << yield
-        end
-      end
-    end
-
-    def can_read_list?(starting_with: nil)
-      if starting_with.nil?
-        peek in [*]
-      else
-        peek in [^starting_with, *]
-      end
-    end
-
-    def finished?
-      s_expression.empty?
-    end
-
-    def peek
-      s_expression.first
-    end
-
-    def read
-      s_expression.shift
     end
   end
 end

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -16,5 +16,51 @@ module Wasminna
         value.ceildiv(kwargs.fetch(:in))
       end
     end
+
+    module ReadFromSExpression
+      private
+
+      def read_list(from: read, starting_with: nil)
+        raise "not a list: #{from.inspect}" unless from in [*]
+        previous_s_expression, self.s_expression = self.s_expression, from
+
+        read => ^starting_with unless starting_with.nil?
+
+        yield.tap do
+          raise unless finished?
+          self.s_expression = previous_s_expression
+        end
+      end
+
+      def repeatedly(**kwargs)
+        terminator = kwargs[:until]
+
+        [].tap do |results|
+          until finished? || (!terminator.nil? && peek in ^terminator)
+            results << yield
+          end
+        end
+      end
+
+      def can_read_list?(starting_with: nil)
+        if starting_with.nil?
+          peek in [*]
+        else
+          peek in [^starting_with, *]
+        end
+      end
+
+      def finished?
+        s_expression.empty?
+      end
+
+      def peek
+        s_expression.first
+      end
+
+      def read
+        s_expression.shift
+      end
+    end
   end
 end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -22,7 +22,9 @@ module Wasminna
             else
               ['module', *inline_module]
             end
-          result.push(process_command(command))
+          read_list(from: command) do
+            result.push(process_command)
+          end
         end
       end
     end
@@ -33,16 +35,14 @@ module Wasminna
 
     attr_accessor :fresh_id, :s_expression
 
-    def process_command(command)
-      read_list(from: command) do
-        case peek
-        in 'module'
-          process_module
-        in 'assert_trap'
-          process_assert_trap
-        else
-          repeatedly { read }
-        end
+    def process_command
+      case peek
+      in 'module'
+        process_module
+      in 'assert_trap'
+        process_assert_trap
+      else
+        repeatedly { read }
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -77,7 +77,9 @@ module Wasminna
           [process_function]
         end
       in ['type', *]
-        [process_type(field)]
+        read_list(from: field) do
+          [process_type]
+        end
       in ['import', *]
         [process_import(field)]
       else
@@ -155,16 +157,14 @@ module Wasminna
       end.flatten(1)
     end
 
-    def process_type(type)
-      read_list(from: type) do
-        read => 'type'
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
-        functype = read_list { process_functype }
-
-        ['type', *id, functype]
+    def process_type
+      read => 'type'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
       end
+      functype = read_list { process_functype }
+
+      ['type', *id, functype]
     end
 
     def process_functype

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -176,9 +176,13 @@ module Wasminna
     end
 
     def process_import(import)
-      import => ['import', module_name, name, descriptor]
-      read_list(from: descriptor) do
-        ['import', module_name, name, process_import_descriptor]
+      read_list(from: import) do
+        read => 'import'
+        read => module_name
+        read => name
+        descriptor = read_list { process_import_descriptor }
+
+        ['import', module_name, name, descriptor]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -45,14 +45,16 @@ module Wasminna
     end
 
     def process_module(mod)
-      case mod
-      in ['module', ID_REGEXP => id, *fields]
-        read_list(from: fields) do
-          ['module', id, *repeatedly { process_field }.flatten(1)]
-        end
-      in ['module', *fields]
-        read_list(from: fields) do
-          ['module', *repeatedly { process_field }.flatten(1)]
+      read_list(from: mod) do
+        read => 'module'
+
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+          fields = repeatedly { process_field }.flatten(1)
+          ['module', *id, *fields]
+        else
+          fields = repeatedly { process_field }.flatten(1)
+          ['module', *id, *fields]
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -87,14 +87,14 @@ module Wasminna
       case function
       in ['func', ID_REGEXP => id, *definition]
         read_list(from: definition) do
-          typeuse = process_typeuse(definition)
+          typeuse = process_typeuse
           locals = process_locals(definition)
           body = process_instructions
           ['func', id, *typeuse, *locals, *body]
         end
       in ['func', *definition]
         read_list(from: definition) do
-          typeuse = process_typeuse(definition)
+          typeuse = process_typeuse
           locals = process_locals(definition)
           body = process_instructions
           ['func', *typeuse, *locals, *body]
@@ -102,12 +102,12 @@ module Wasminna
       end
     end
 
-    def process_typeuse(definition)
-      if definition in [['type', *], *]
-        type = [definition.shift]
+    def process_typeuse
+      if can_read_list?(starting_with: 'type')
+        type = [read]
       end
-      parameters = process_parameters(definition)
-      results = process_results(definition)
+      parameters = process_parameters(s_expression)
+      results = process_results(s_expression)
 
       [*type, *parameters, *results]
     end
@@ -185,9 +185,13 @@ module Wasminna
     def process_import_descriptor(descriptor)
       case descriptor
       in ['func', ID_REGEXP => id, *typeuse]
-        ['func', id, *process_typeuse(typeuse)]
+        read_list(from: typeuse) do
+          ['func', id, *process_typeuse]
+        end
       in ['func', *typeuse]
-        ['func', *process_typeuse(typeuse)]
+        read_list(from: typeuse) do
+          ['func', *process_typeuse]
+        end
       else
         descriptor
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -158,20 +158,22 @@ module Wasminna
     def process_type(type)
       case type
       in ['type', ID_REGEXP => id, definition]
-        ['type', id, process_functype(definition)]
+        read_list(from: definition) do
+          ['type', id, process_functype]
+        end
       in ['type', definition]
-        ['type', process_functype(definition)]
+        read_list(from: definition) do
+          ['type', process_functype]
+        end
       end
     end
 
-    def process_functype(definition)
-      read_list(from: definition) do
-        read => 'func'
-        parameters = process_parameters(s_expression)
-        results = process_results(s_expression)
+    def process_functype
+      read => 'func'
+      parameters = process_parameters(s_expression)
+      results = process_results(s_expression)
 
-        ['func', *parameters, *results]
-      end
+      ['func', *parameters, *results]
     end
 
     def process_import(import)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -40,7 +40,9 @@ module Wasminna
           process_module
         end
       in 'assert_trap'
-        process_assert_trap(command)
+        read_list(from: command) do
+          process_assert_trap
+        end
       else
         command
       end
@@ -236,18 +238,16 @@ module Wasminna
       end
     end
 
-    def process_assert_trap(assertion)
-      read_list(from: assertion) do
-        read => 'assert_trap'
+    def process_assert_trap
+      read => 'assert_trap'
 
-        if can_read_list?(starting_with: 'module')
-          mod = read_list { process_module }
-          read => failure
+      if can_read_list?(starting_with: 'module')
+        mod = read_list { process_module }
+        read => failure
 
-          ['assert_trap', mod, failure]
-        else
-          ['assert_trap', *repeatedly { read }]
-        end
+        ['assert_trap', mod, failure]
+      else
+        ['assert_trap', *repeatedly { read }]
       end
     end
   end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -84,18 +84,18 @@ module Wasminna
     end
 
     def process_function(function)
-      case function
-      in ['func', ID_REGEXP => id, *definition]
-        read_list(from: definition) do
+      read_list(from: function) do
+        read => 'func'
+
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
           typeuse = process_typeuse
-          locals = process_locals(definition)
+          locals = process_locals(s_expression)
           body = process_instructions
           ['func', id, *typeuse, *locals, *body]
-        end
-      in ['func', *definition]
-        read_list(from: definition) do
+        else
           typeuse = process_typeuse
-          locals = process_locals(definition)
+          locals = process_locals(s_expression)
           body = process_instructions
           ['func', *typeuse, *locals, *body]
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -36,7 +36,9 @@ module Wasminna
     def process_command(command)
       case command.first
       in 'module'
-        process_module(command)
+        read_list(from: command) do
+          process_module
+        end
       in 'assert_trap'
         process_assert_trap(command)
       else
@@ -44,16 +46,14 @@ module Wasminna
       end
     end
 
-    def process_module(mod)
-      read_list(from: mod) do
-        read => 'module'
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
-        fields = repeatedly { process_field }.flatten(1)
-
-        ['module', *id, *fields]
+    def process_module
+      read => 'module'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
       end
+      fields = repeatedly { process_field }.flatten(1)
+
+      ['module', *id, *fields]
     end
 
     def process_field
@@ -239,7 +239,9 @@ module Wasminna
     def process_assert_trap(assertion)
       case assertion
       in ['assert_trap', ['module', *] => mod, failure]
-        ['assert_trap', process_module(mod), failure]
+        read_list(from: mod) do
+          ['assert_trap', process_module, failure]
+        end
       else
         assertion
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -81,7 +81,9 @@ module Wasminna
           [process_type]
         end
       in ['import', *]
-        [process_import(field)]
+        read_list(from: field) do
+          [process_import]
+        end
       else
         [field]
       end
@@ -175,15 +177,13 @@ module Wasminna
       ['func', *parameters, *results]
     end
 
-    def process_import(import)
-      read_list(from: import) do
-        read => 'import'
-        read => module_name
-        read => name
-        descriptor = read_list { process_import_descriptor }
+    def process_import
+      read => 'import'
+      read => module_name
+      read => name
+      descriptor = read_list { process_import_descriptor }
 
-        ['import', module_name, name, descriptor]
-      end
+      ['import', module_name, name, descriptor]
     end
 
     def process_import_descriptor

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -165,11 +165,13 @@ module Wasminna
     end
 
     def process_functype(definition)
-      definition.shift => 'func'
-      parameters = process_parameters(definition)
-      results = process_results(definition)
+      read_list(from: definition) do
+        read => 'func'
+        parameters = process_parameters(s_expression)
+        results = process_results(s_expression)
 
-      ['func', *parameters, *results]
+        ['func', *parameters, *results]
+      end
     end
 
     def process_import(import)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -158,15 +158,12 @@ module Wasminna
     def process_type(type)
       read_list(from: type) do
         read => 'type'
-
         if peek in ID_REGEXP
           read => ID_REGEXP => id
-          functype = read_list { process_functype }
-          ['type', id, functype]
-        else
-          functype = read_list { process_functype }
-          ['type', functype]
         end
+        functype = read_list { process_functype }
+
+        ['type', *id, functype]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -34,17 +34,15 @@ module Wasminna
     attr_accessor :fresh_id, :s_expression
 
     def process_command(command)
-      case command.first
-      in 'module'
-        read_list(from: command) do
+      read_list(from: command) do
+        case peek
+        in 'module'
           process_module
-        end
-      in 'assert_trap'
-        read_list(from: command) do
+        in 'assert_trap'
           process_assert_trap
+        else
+          repeatedly { read }
         end
-      else
-        command
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -47,9 +47,13 @@ module Wasminna
     def process_module(mod)
       case mod
       in ['module', ID_REGEXP => id, *fields]
-        ['module', id, *fields.flat_map { process_field(_1) }]
+        read_list(from: fields) do
+          ['module', id, *repeatedly { process_field(read) }.flatten(1)]
+        end
       in ['module', *fields]
-        ['module', *fields.flat_map { process_field(_1) }]
+        read_list(from: fields) do
+          ['module', *repeatedly { process_field(read) }.flatten(1)]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -95,7 +95,7 @@ module Wasminna
         read => ID_REGEXP => id
       end
       typeuse = process_typeuse
-      locals = process_locals(s_expression)
+      locals = process_locals
       body = process_instructions
 
       ['func', *id, *typeuse, *locals, *body]
@@ -105,22 +105,22 @@ module Wasminna
       if can_read_list?(starting_with: 'type')
         type = [read]
       end
-      parameters = process_parameters(s_expression)
-      results = process_results(s_expression)
+      parameters = process_parameters
+      results = process_results
 
       [*type, *parameters, *results]
     end
 
-    def process_parameters(definition)
-      expand_anonymous_declarations(definition, kind: 'param')
+    def process_parameters
+      expand_anonymous_declarations(s_expression, kind: 'param')
     end
 
-    def process_results(definition)
-      expand_anonymous_declarations(definition, kind: 'result')
+    def process_results
+      expand_anonymous_declarations(s_expression, kind: 'result')
     end
 
-    def process_locals(definition)
-      expand_anonymous_declarations(definition, kind: 'local')
+    def process_locals
+      expand_anonymous_declarations(s_expression, kind: 'local')
     end
 
     def expand_anonymous_declarations(s_expression, kind:)
@@ -171,8 +171,8 @@ module Wasminna
 
     def process_functype
       read => 'func'
-      parameters = process_parameters(s_expression)
-      results = process_results(s_expression)
+      parameters = process_parameters
+      results = process_results
 
       ['func', *parameters, *results]
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -102,11 +102,12 @@ module Wasminna
         self.fresh_id += 1
       end
       read => ['export', name]
-      rest = repeatedly { read }
+      field = [kind, id, *repeatedly { read }]
+      processed_field = read_list(from: [field]) { process_field(read) }
 
       [
         ['export', name, [kind, id]],
-        *read_list(from: [[kind, id, *rest]]) { process_field(read) }
+        *processed_field
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -86,19 +86,14 @@ module Wasminna
     def process_function(function)
       read_list(from: function) do
         read => 'func'
-
         if peek in ID_REGEXP
           read => ID_REGEXP => id
-          typeuse = process_typeuse
-          locals = process_locals(s_expression)
-          body = process_instructions
-          ['func', id, *typeuse, *locals, *body]
-        else
-          typeuse = process_typeuse
-          locals = process_locals(s_expression)
-          body = process_instructions
-          ['func', *typeuse, *locals, *body]
         end
+        typeuse = process_typeuse
+        locals = process_locals(s_expression)
+        body = process_instructions
+
+        ['func', *id, *typeuse, *locals, *body]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -1,5 +1,9 @@
+require 'wasminna/helpers'
+
 module Wasminna
   class Preprocessor
+    include Helpers::ReadFromSExpression
+
     def initialize
       self.fresh_id = 0
     end
@@ -27,7 +31,7 @@ module Wasminna
 
     ID_REGEXP = %r{\A\$}
 
-    attr_accessor :fresh_id
+    attr_accessor :fresh_id, :s_expression
 
     def process_command(command)
       case command.first

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -156,14 +156,16 @@ module Wasminna
     end
 
     def process_type(type)
-      case type
-      in ['type', ID_REGEXP => id, definition]
-        read_list(from: definition) do
-          ['type', id, process_functype]
-        end
-      in ['type', definition]
-        read_list(from: definition) do
-          ['type', process_functype]
+      read_list(from: type) do
+        read => 'type'
+
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+          functype = read_list { process_functype }
+          ['type', id, functype]
+        else
+          functype = read_list { process_functype }
+          ['type', functype]
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -237,13 +237,17 @@ module Wasminna
     end
 
     def process_assert_trap(assertion)
-      case assertion
-      in ['assert_trap', ['module', *] => mod, failure]
-        read_list(from: mod) do
-          ['assert_trap', process_module, failure]
+      read_list(from: assertion) do
+        read => 'assert_trap'
+
+        if can_read_list?(starting_with: 'module')
+          mod = read_list { process_module }
+          read => failure
+
+          ['assert_trap', mod, failure]
+        else
+          ['assert_trap', *repeatedly { read }]
         end
-      else
-        assertion
       end
     end
   end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -181,17 +181,20 @@ module Wasminna
     end
 
     def process_import_descriptor(descriptor)
-      case descriptor
-      in ['func', ID_REGEXP => id, *typeuse]
-        read_list(from: typeuse) do
-          ['func', id, *process_typeuse]
+      read_list(from: descriptor) do
+        case peek
+        when 'func'
+          read => 'func'
+
+          if peek in ID_REGEXP
+            read => ID_REGEXP => id
+            ['func', *id, *process_typeuse]
+          else
+            ['func', *process_typeuse]
+          end
+        else
+          repeatedly { read }
         end
-      in ['func', *typeuse]
-        read_list(from: typeuse) do
-          ['func', *process_typeuse]
-        end
-      else
-        descriptor
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -177,22 +177,22 @@ module Wasminna
 
     def process_import(import)
       import => ['import', module_name, name, descriptor]
-      ['import', module_name, name, process_import_descriptor(descriptor)]
+      read_list(from: descriptor) do
+        ['import', module_name, name, process_import_descriptor]
+      end
     end
 
-    def process_import_descriptor(descriptor)
-      read_list(from: descriptor) do
-        case peek
-        when 'func'
-          read => 'func'
-          if peek in ID_REGEXP
-            read => ID_REGEXP => id
-          end
-
-          ['func', *id, *process_typeuse]
-        else
-          repeatedly { read }
+    def process_import_descriptor
+      case peek
+      when 'func'
+        read => 'func'
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
         end
+
+        ['func', *id, *process_typeuse]
+      else
+        repeatedly { read }
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -9,21 +9,21 @@ module Wasminna
     end
 
     def process_script(s_expression)
-      [].tap do |result|
-        until s_expression.empty?
+      read_list(from: s_expression) do
+        repeatedly do
           inline_module = []
-          while s_expression in [['type' | 'import' | 'func' | 'table' | 'memory' | 'global' | 'export' | 'start' | 'elem' | 'data', *], *]
-            inline_module.push(s_expression.shift)
+          while peek in ['type' | 'import' | 'func' | 'table' | 'memory' | 'global' | 'export' | 'start' | 'elem' | 'data', *]
+            inline_module.push(read)
           end
 
           command =
             if inline_module.empty?
-              s_expression.shift
+              read
             else
               ['module', *inline_module]
             end
           read_list(from: command) do
-            result.push(process_command)
+            process_command
           end
         end
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -73,7 +73,9 @@ module Wasminna
           *process_field([kind, id, *rest])
         ]
       in ['func', *]
-        [process_function(field)]
+        read_list(from: field) do
+          [process_function]
+        end
       in ['type', *]
         [process_type(field)]
       in ['import', *]
@@ -83,18 +85,16 @@ module Wasminna
       end
     end
 
-    def process_function(function)
-      read_list(from: function) do
-        read => 'func'
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
-        typeuse = process_typeuse
-        locals = process_locals(s_expression)
-        body = process_instructions
-
-        ['func', *id, *typeuse, *locals, *body]
+    def process_function
+      read => 'func'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
       end
+      typeuse = process_typeuse
+      locals = process_locals(s_expression)
+      body = process_instructions
+
+      ['func', *id, *typeuse, *locals, *body]
     end
 
     def process_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -185,13 +185,11 @@ module Wasminna
         case peek
         when 'func'
           read => 'func'
-
           if peek in ID_REGEXP
             read => ID_REGEXP => id
-            ['func', *id, *process_typeuse]
-          else
-            ['func', *process_typeuse]
           end
+
+          ['func', *id, *process_typeuse]
         else
           repeatedly { read }
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -64,22 +64,21 @@ module Wasminna
           read_list(from: field) do
             expand_inline_export
           end
-        in ['func', *]
-          read_list(from: field) do
-            [process_function]
-          end
-        in ['type', *]
-          read_list(from: field) do
-            [process_type]
-          end
-        in ['import', *]
-          read_list(from: field) do
-            [process_import]
-          end
         else
-          read_list(from: field) do
-            [repeatedly { read }]
-          end
+          [
+            read_list(from: field) do
+              case peek
+              in 'func'
+                process_function
+              in 'type'
+                process_type
+              in 'import'
+                process_import
+              else
+                repeatedly { read }
+              end
+            end
+          ]
         end
       else
         [field]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -47,15 +47,12 @@ module Wasminna
     def process_module(mod)
       read_list(from: mod) do
         read => 'module'
-
         if peek in ID_REGEXP
           read => ID_REGEXP => id
-          fields = repeatedly { process_field }.flatten(1)
-          ['module', *id, *fields]
-        else
-          fields = repeatedly { process_field }.flatten(1)
-          ['module', *id, *fields]
         end
+        fields = repeatedly { process_field }.flatten(1)
+
+        ['module', *id, *fields]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -54,26 +54,32 @@ module Wasminna
     end
 
     def process_field(field)
-      case field
-      in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['func' | 'table' | 'memory' | 'global', ['import', _, _], *]
-        read_list(from: field) do
-          expand_inline_import
-        end
-      in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['func' | 'table' | 'memory' | 'global', ['export', _], *]
-        read_list(from: field) do
-          expand_inline_export
-        end
-      in ['func', *]
-        read_list(from: field) do
-          [process_function]
-        end
-      in ['type', *]
-        read_list(from: field) do
-          [process_type]
-        end
-      in ['import', *]
-        read_list(from: field) do
-          [process_import]
+      if field in [*]
+        case field
+        in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['func' | 'table' | 'memory' | 'global', ['import', _, _], *]
+          read_list(from: field) do
+            expand_inline_import
+          end
+        in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['func' | 'table' | 'memory' | 'global', ['export', _], *]
+          read_list(from: field) do
+            expand_inline_export
+          end
+        in ['func', *]
+          read_list(from: field) do
+            [process_function]
+          end
+        in ['type', *]
+          read_list(from: field) do
+            [process_type]
+          end
+        in ['import', *]
+          read_list(from: field) do
+            [process_import]
+          end
+        else
+          read_list(from: field) do
+            [repeatedly { read }]
+          end
         end
       else
         [field]

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -313,4 +313,17 @@ else
   raise actual.inspect unless actual == expected
 end
 
+input = [
+  %w[module $M2 binary "\00asm" "\01\00\00\00"]
+]
+expected = [
+  %w[module $M2 binary "\00asm" "\01\00\00\00"]
+]
+actual = Wasminna::Preprocessor.new.process_script(input)
+if actual == expected
+  print "\e[32m.\e[0m"
+else
+  raise actual.inspect unless actual == expected
+end
+
 puts


### PR DESCRIPTION
The preprocessor is inconsistent in its implementation. At a high level it works differently from the AST parser: rather than storing an S-expression in its current state and incrementally consuming it, it instead passes a single S-expression around as an argument between its methods. These methods are themselves inconsistent in how they process their argument, sometimes destructively consuming it with `Array#shift`, sometimes harmlessly dismantling it with pattern matching.

This PR refactors the processor to work like the AST parser. The S-expression is passed between methods as state and is destructively consumed by preprocessing. This unifies the style of both implementations and makes it easier to support syntactic features like optional IDs.