### PR TITLE
Handle each kind of module field separately in preprocessor

### DIFF
--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -154,15 +154,17 @@ module Wasminna
       if peek in ID_REGEXP
         read => ID_REGEXP => id
       end
+      read => ['export', name]
+      description = repeatedly { read }
+
       if id.nil?
         id = "$__fresh_#{fresh_id}" # TODO find a better way
         self.fresh_id += 1
       end
-      read => ['export', name]
       expanded =
         [
           ['export', name, [kind, id]],
-          [kind, id, *repeatedly { read }]
+          [kind, id, *description]
         ]
 
       read_list(from: expanded) { process_fields }

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -119,7 +119,7 @@ module Wasminna
       end
       read => ['export', name]
       field = [kind, id, *repeatedly { read }]
-      processed_field = read_list(from: [field]) { read_list { process_field } }
+      processed_field = read_list(from: field) { process_field }
 
       [
         ['export', name, [kind, id]],

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -130,16 +130,14 @@ module Wasminna
     end
 
     def expand_inline_import_export(**)
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
+
       case s_expression
-      in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
+      in [['import', _, _], *]
         expand_inline_import(**, id:)
-      in [ID_REGEXP, ['export', _], *] | [['export', _], *]
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
+      in [['export', _], *]
         expand_inline_export(**, id:)
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -77,9 +77,9 @@ module Wasminna
 
     def process_field
       case s_expression
-      in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['func' | 'table' | 'memory' | 'global', ['import', _, _], *]
+      in ['table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['table' | 'memory' | 'global', ['import', _, _], *]
         expand_inline_import
-      in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['func' | 'table' | 'memory' | 'global', ['export', _], *]
+      in ['table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['table' | 'memory' | 'global', ['export', _], *]
         expand_inline_export
       else
         case peek

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -93,9 +93,11 @@ module Wasminna
     def process_function_definition
       case s_expression
       in ['func', ID_REGEXP, ['import', _, _], *] | ['func', ['import', _, _], *]
-        expand_inline_import
+        read => 'func'
+        expand_inline_import(kind: 'func')
       in ['func', ID_REGEXP, ['export', _], *] | ['func', ['export', _], *]
-        expand_inline_export
+        read => 'func'
+        expand_inline_export(kind: 'func')
       else
         read => 'func'
         if peek in ID_REGEXP
@@ -114,16 +116,17 @@ module Wasminna
     def process_table_memory_global_definition
       case s_expression
       in ['table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['table' | 'memory' | 'global', ['import', _, _], *]
-        expand_inline_import
+        read => 'table' | 'memory' | 'global' => kind
+        expand_inline_import(kind:)
       in ['table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['table' | 'memory' | 'global', ['export', _], *]
-        expand_inline_export
+        read => 'table' | 'memory' | 'global' => kind
+        expand_inline_export(kind:)
       else
         [repeatedly { read }]
       end
     end
 
-    def expand_inline_import
-      read => 'func' | 'table' | 'memory' | 'global' => kind
+    def expand_inline_import(kind:)
       if peek in ID_REGEXP
         read => ID_REGEXP => id
       end
@@ -135,8 +138,7 @@ module Wasminna
       ]
     end
 
-    def expand_inline_export
-      read => 'func' | 'table' | 'memory' | 'global' => kind
+    def expand_inline_export(kind:)
       if peek in ID_REGEXP
         read => ID_REGEXP => id
       else

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -92,16 +92,13 @@ module Wasminna
 
     def process_function_definition
       read => 'func'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
 
       if can_read_inline_import_export?
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
         expand_inline_import_export(kind: 'func', id:)
       else
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
         typeuse = process_typeuse
         locals = process_locals
         body = process_instructions
@@ -114,25 +111,23 @@ module Wasminna
 
     def process_table_memory_global_definition
       read => 'table' | 'memory' | 'global' => kind
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
 
       if can_read_inline_import_export?
-        if peek in ID_REGEXP
-          read => ID_REGEXP => id
-        end
         expand_inline_import_export(kind:, id:)
       else
         rest = repeatedly { read }
 
         [
-          [kind, *rest]
+          [kind, *id, *rest]
         ]
       end
     end
 
     def can_read_inline_import_export?
-      s_expression in
-        [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *] |
-        [ID_REGEXP, ['export', _], *] | [['export', _], *]
+      s_expression in [['import', _, _], *] | [['export', _], *]
     end
 
     def expand_inline_import_export(**)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -127,14 +127,14 @@ module Wasminna
     end
 
     def can_read_inline_import_export?
-      s_expression in [['import', _, _], *] | [['export', _], *]
+      peek in ['import', _, _] | ['export', _]
     end
 
     def expand_inline_import_export(**)
-      case s_expression
-      in [['import', _, _], *]
+      case peek
+      in ['import', _, _]
         expand_inline_import(**)
-      in [['export', _], *]
+      in ['export', _]
         expand_inline_export(**)
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -75,18 +75,14 @@ module Wasminna
     end
 
     def process_field
-      case peek
-      in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['func' | 'table' | 'memory' | 'global', ['import', _, _], *]
-        read_list do
+      read_list do
+        case s_expression
+        in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['func' | 'table' | 'memory' | 'global', ['import', _, _], *]
           expand_inline_import
-        end
-      in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['func' | 'table' | 'memory' | 'global', ['export', _], *]
-        read_list do
+        in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['func' | 'table' | 'memory' | 'global', ['export', _], *]
           expand_inline_export
-        end
-      else
-        [
-          read_list do
+        else
+          [
             case peek
             in 'func'
               process_function
@@ -97,8 +93,8 @@ module Wasminna
             else
               repeatedly { read }
             end
-          end
-        ]
+          ]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -69,9 +69,15 @@ module Wasminna
         strings = repeatedly { read }
         ['module', *id, 'binary', *strings]
       else
-        fields = repeatedly { read_list { process_field } }.flatten(1)
+        fields = process_fields
         ['module', *id, *fields]
       end
+    end
+
+    def process_fields
+      repeatedly do
+        read_list { process_field }
+      end.flatten(1)
     end
 
     def process_field

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -76,24 +76,17 @@ module Wasminna
     end
 
     def process_field
-      case s_expression
-      in ['table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['table' | 'memory' | 'global', ['import', _, _], *]
-        expand_inline_import
-      in ['table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['table' | 'memory' | 'global', ['export', _], *]
-        expand_inline_export
+      case peek
+      in 'func'
+        process_function_definition
+      in 'table' | 'memory' | 'global'
+        process_table_memory_global_definition
+      in 'type'
+        process_type_definition
+      in 'import'
+        process_import
       else
-        case peek
-        in 'func'
-          process_function_definition
-        in 'table' | 'memory' | 'global'
-          process_table_memory_global_definition
-        in 'type'
-          process_type_definition
-        in 'import'
-          process_import
-        else
-          [repeatedly { read }]
-        end
+        [repeatedly { read }]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -153,7 +153,8 @@ module Wasminna
     def expand_inline_export(kind:)
       if peek in ID_REGEXP
         read => ID_REGEXP => id
-      else
+      end
+      if id.nil?
         id = "$__fresh_#{fresh_id}" # TODO find a better way
         self.fresh_id += 1
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -84,9 +84,9 @@ module Wasminna
       else
         case peek
         in 'func'
-          process_function
+          process_function_definition
         in 'type'
-          process_type
+          process_type_definition
         in 'import'
           process_import
         else
@@ -126,7 +126,7 @@ module Wasminna
       read_list(from: expanded) { process_fields }
     end
 
-    def process_function
+    def process_function_definition
       read => 'func'
       if peek in ID_REGEXP
         read => ID_REGEXP => id
@@ -204,7 +204,7 @@ module Wasminna
       end.flatten(1)
     end
 
-    def process_type
+    def process_type_definition
       read => 'type'
       if peek in ID_REGEXP
         read => ID_REGEXP => id

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -124,13 +124,13 @@ module Wasminna
         self.fresh_id += 1
       end
       read => ['export', name]
-      field = [kind, id, *repeatedly { read }]
-      processed_field = read_list(from: field) { process_field }
+      expanded =
+        [
+          ['export', name, [kind, id]],
+          [kind, id, *repeatedly { read }]
+        ]
 
-      [
-        ['export', name, [kind, id]],
-        *processed_field
-      ]
+      read_list(from: expanded) { process_fields }
     end
 
     def process_function

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -127,17 +127,24 @@ module Wasminna
     end
 
     def process_function_definition
-      read => 'func'
-      if peek in ID_REGEXP
-        read => ID_REGEXP => id
-      end
-      typeuse = process_typeuse
-      locals = process_locals
-      body = process_instructions
+      case s_expression
+      in ['func', ID_REGEXP, ['import', _, _], *] | ['func', ['import', _, _], *]
+        expand_inline_import
+      in ['func', ID_REGEXP, ['export', _], *] | ['func', ['export', _], *]
+        expand_inline_export
+      else
+        read => 'func'
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+        end
+        typeuse = process_typeuse
+        locals = process_locals
+        body = process_instructions
 
-      [
-        ['func', *id, *typeuse, *locals, *body]
-      ]
+        [
+          ['func', *id, *typeuse, *locals, *body]
+        ]
+      end
     end
 
     def process_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -90,37 +90,6 @@ module Wasminna
       end
     end
 
-    def expand_inline_import
-      read => 'func' | 'table' | 'memory' | 'global' => kind
-      if peek in ID_REGEXP
-        read => ID_REGEXP => id
-      end
-      read => ['import', module_name, name]
-      description = repeatedly { read }
-
-      [
-        ['import', module_name, name, [kind, *id, *description]]
-      ]
-    end
-
-    def expand_inline_export
-      read => 'func' | 'table' | 'memory' | 'global' => kind
-      if peek in ID_REGEXP
-        read => ID_REGEXP => id
-      else
-        id = "$__fresh_#{fresh_id}" # TODO find a better way
-        self.fresh_id += 1
-      end
-      read => ['export', name]
-      expanded =
-        [
-          ['export', name, [kind, id]],
-          [kind, id, *repeatedly { read }]
-        ]
-
-      read_list(from: expanded) { process_fields }
-    end
-
     def process_function_definition
       case s_expression
       in ['func', ID_REGEXP, ['import', _, _], *] | ['func', ['import', _, _], *]
@@ -151,6 +120,37 @@ module Wasminna
       else
         [repeatedly { read }]
       end
+    end
+
+    def expand_inline_import
+      read => 'func' | 'table' | 'memory' | 'global' => kind
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
+      read => ['import', module_name, name]
+      description = repeatedly { read }
+
+      [
+        ['import', module_name, name, [kind, *id, *description]]
+      ]
+    end
+
+    def expand_inline_export
+      read => 'func' | 'table' | 'memory' | 'global' => kind
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      else
+        id = "$__fresh_#{fresh_id}" # TODO find a better way
+        self.fresh_id += 1
+      end
+      read => ['export', name]
+      expanded =
+        [
+          ['export', name, [kind, id]],
+          [kind, id, *repeatedly { read }]
+        ]
+
+      read_list(from: expanded) { process_fields }
     end
 
     def process_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -94,7 +94,10 @@ module Wasminna
       read => 'func'
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'func')
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+        end
+        expand_inline_import_export(kind: 'func', id:)
       else
         if peek in ID_REGEXP
           read => ID_REGEXP => id
@@ -113,7 +116,10 @@ module Wasminna
       read => 'table' | 'memory' | 'global' => kind
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind:)
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+        end
+        expand_inline_import_export(kind:, id:)
       else
         rest = repeatedly { read }
 
@@ -130,15 +136,11 @@ module Wasminna
     end
 
     def expand_inline_import_export(**)
-      if peek in ID_REGEXP
-        read => ID_REGEXP => id
-      end
-
       case s_expression
       in [['import', _, _], *]
-        expand_inline_import(**, id:)
+        expand_inline_import(**)
       in [['export', _], *]
-        expand_inline_export(**, id:)
+        expand_inline_export(**)
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -82,18 +82,16 @@ module Wasminna
       in ['func' | 'table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['func' | 'table' | 'memory' | 'global', ['export', _], *]
         expand_inline_export
       else
-        [
-          case peek
-          in 'func'
-            process_function
-          in 'type'
-            process_type
-          in 'import'
-            process_import
-          else
-            repeatedly { read }
-          end
-        ]
+        case peek
+        in 'func'
+          process_function
+        in 'type'
+          process_type
+        in 'import'
+          process_import
+        else
+          [repeatedly { read }]
+        end
       end
     end
 
@@ -137,7 +135,9 @@ module Wasminna
       locals = process_locals
       body = process_instructions
 
-      ['func', *id, *typeuse, *locals, *body]
+      [
+        ['func', *id, *typeuse, *locals, *body]
+      ]
     end
 
     def process_typeuse
@@ -211,7 +211,9 @@ module Wasminna
       end
       functype = read_list { process_functype }
 
-      ['type', *id, functype]
+      [
+        ['type', *id, functype]
+      ]
     end
 
     def process_functype
@@ -228,7 +230,9 @@ module Wasminna
       read => name
       descriptor = read_list { process_import_descriptor }
 
-      ['import', module_name, name, descriptor]
+      [
+        ['import', module_name, name, descriptor]
+      ]
     end
 
     def process_import_descriptor

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -91,15 +91,14 @@ module Wasminna
     end
 
     def process_function_definition
+      read => 'func'
+
       case s_expression
-      in ['func', ID_REGEXP, ['import', _, _], *] | ['func', ['import', _, _], *]
-        read => 'func'
+      in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
         expand_inline_import(kind: 'func')
-      in ['func', ID_REGEXP, ['export', _], *] | ['func', ['export', _], *]
-        read => 'func'
+      in [ID_REGEXP, ['export', _], *] | [['export', _], *]
         expand_inline_export(kind: 'func')
       else
-        read => 'func'
         if peek in ID_REGEXP
           read => ID_REGEXP => id
         end
@@ -114,15 +113,19 @@ module Wasminna
     end
 
     def process_table_memory_global_definition
+      read => 'table' | 'memory' | 'global' => kind
+
       case s_expression
-      in ['table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['table' | 'memory' | 'global', ['import', _, _], *]
-        read => 'table' | 'memory' | 'global' => kind
+      in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
         expand_inline_import(kind:)
-      in ['table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['table' | 'memory' | 'global', ['export', _], *]
-        read => 'table' | 'memory' | 'global' => kind
+      in [ID_REGEXP, ['export', _], *] | [['export', _], *]
         expand_inline_export(kind:)
       else
-        [repeatedly { read }]
+        rest = repeatedly { read }
+
+        [
+          [kind, *rest]
+        ]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -79,8 +79,12 @@ module Wasminna
       case peek
       in 'func'
         process_function_definition
-      in 'table' | 'memory' | 'global'
-        process_table_memory_global_definition
+      in 'table'
+        process_table_definition
+      in 'memory'
+        process_memory_definition
+      in 'global'
+        process_global_definition
       in 'type'
         process_type_definition
       in 'import'
@@ -109,19 +113,53 @@ module Wasminna
       end
     end
 
-    def process_table_memory_global_definition
-      read => 'table' | 'memory' | 'global' => kind
+    def process_table_definition
+      read => 'table'
       if peek in ID_REGEXP
         read => ID_REGEXP => id
       end
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind:, id:)
+        expand_inline_import_export(kind: 'table', id:)
       else
         rest = repeatedly { read }
 
         [
-          [kind, *id, *rest]
+          ['table', *id, *rest]
+        ]
+      end
+    end
+
+    def process_memory_definition
+      read => 'memory'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
+
+      if can_read_inline_import_export?
+        expand_inline_import_export(kind: 'memory', id:)
+      else
+        rest = repeatedly { read }
+
+        [
+          ['memory', *id, *rest]
+        ]
+      end
+    end
+
+    def process_global_definition
+      read => 'global'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
+
+      if can_read_inline_import_export?
+        expand_inline_import_export(kind: 'global', id:)
+      else
+        rest = repeatedly { read }
+
+        [
+          ['global', *id, *rest]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -132,16 +132,19 @@ module Wasminna
     def expand_inline_import_export(**)
       case s_expression
       in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
-        expand_inline_import(**)
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+        end
+        expand_inline_import(**, id:)
       in [ID_REGEXP, ['export', _], *] | [['export', _], *]
-        expand_inline_export(**)
+        if peek in ID_REGEXP
+          read => ID_REGEXP => id
+        end
+        expand_inline_export(**, id:)
       end
     end
 
-    def expand_inline_import(kind:)
-      if peek in ID_REGEXP
-        read => ID_REGEXP => id
-      end
+    def expand_inline_import(kind:, id:)
       read => ['import', module_name, name]
       description = repeatedly { read }
 
@@ -150,10 +153,7 @@ module Wasminna
       ]
     end
 
-    def expand_inline_export(kind:)
-      if peek in ID_REGEXP
-        read => ID_REGEXP => id
-      end
+    def expand_inline_export(kind:, id:)
       read => ['export', name]
       description = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -85,6 +85,8 @@ module Wasminna
         case peek
         in 'func'
           process_function_definition
+        in 'table' | 'memory' | 'global'
+          process_table_memory_global_definition
         in 'type'
           process_type_definition
         in 'import'
@@ -144,6 +146,17 @@ module Wasminna
         [
           ['func', *id, *typeuse, *locals, *body]
         ]
+      end
+    end
+
+    def process_table_memory_global_definition
+      case s_expression
+      in ['table' | 'memory' | 'global', ID_REGEXP, ['import', _, _], *] | ['table' | 'memory' | 'global', ['import', _, _], *]
+        expand_inline_import
+      in ['table' | 'memory' | 'global', ID_REGEXP, ['export', _], *] | ['table' | 'memory' | 'global', ['export', _], *]
+        expand_inline_export
+      else
+        [repeatedly { read }]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -93,11 +93,8 @@ module Wasminna
     def process_function_definition
       read => 'func'
 
-      case s_expression
-      in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
-        expand_inline_import(kind: 'func')
-      in [ID_REGEXP, ['export', _], *] | [['export', _], *]
-        expand_inline_export(kind: 'func')
+      if can_read_inline_import_export?
+        expand_inline_import_export(kind: 'func')
       else
         if peek in ID_REGEXP
           read => ID_REGEXP => id
@@ -115,17 +112,29 @@ module Wasminna
     def process_table_memory_global_definition
       read => 'table' | 'memory' | 'global' => kind
 
-      case s_expression
-      in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
-        expand_inline_import(kind:)
-      in [ID_REGEXP, ['export', _], *] | [['export', _], *]
-        expand_inline_export(kind:)
+      if can_read_inline_import_export?
+        expand_inline_import_export(kind:)
       else
         rest = repeatedly { read }
 
         [
           [kind, *rest]
         ]
+      end
+    end
+
+    def can_read_inline_import_export?
+      s_expression in
+        [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *] |
+        [ID_REGEXP, ['export', _], *] | [['export', _], *]
+    end
+
+    def expand_inline_import_export(**)
+      case s_expression
+      in [ID_REGEXP, ['import', _, _], *] | [['import', _, _], *]
+        expand_inline_import(**)
+      in [ID_REGEXP, ['export', _], *] | [['export', _], *]
+        expand_inline_export(**)
       end
     end
 


### PR DESCRIPTION
Different WebAssembly [module fields](https://webassembly.github.io/spec/core/text/modules.html#text-modulefield) can use different abbreviations, so the preprocessor ultimately needs to treat each kind of field separately. As mentioned in 4caaf544c1432b13ba93dd4f5a9dd1b379005a15, the work of expanding inline imports & exports currently requires looking at the entire field at once and therefore prevents us from first identifying the field and then consuming it incrementally with `peek` and `read` as is done elsewhere.

This PR refactors the preprocessor’s #process_field method to do nothing except peek at the field’s first atom and call the appropriate method for handling that kind of field. This regularises the preprocessor’s implementation and will make it easier to extend the individual field-specific methods to support whatever abbreviations they need.