### PR TITLE
Tidy up the tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,14 +19,14 @@ done
 for file in "$WASM_SPEC_PATH"/test/core/*.wast
 do
   printf "\e[1m%s\e[0m: " "$(basename "$file")"
-  ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/run_wast.rb $file
+  ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/run_wast.rb "$file"
 done
 
 for pending in
 do
   file=$pending.wast
   printf "\e[1m%s\e[0m (pending): " "$(basename "$file")"
-  if ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/run_wast.rb "$WASM_SPEC_PATH"/test/core/$file; then
+  if ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/run_wast.rb "$WASM_SPEC_PATH"/test/core/"$file"; then
     printf "\e[31merror: pending test passed\e[0m\n"
     exit 1
   else

--- a/test.sh
+++ b/test.sh
@@ -12,20 +12,20 @@ fi
 for test in s_expression_parser_test float_test preprocessor_test execute_function_test
 do
   file=$test.rb
-  printf "\e[1m%s\e[0m: " "$file"
+  printf "\e[1m%s\e[0m: " "$(basename "$file")"
   ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/test/$file
 done
 
 for file in "$WASM_SPEC_PATH"/test/core/*.wast
 do
-  printf "\e[1m%s\e[0m: " "$file"
+  printf "\e[1m%s\e[0m: " "$(basename "$file")"
   ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/run_wast.rb $file
 done
 
 for pending in
 do
   file=$pending.wast
-  printf "\e[1m%s\e[0m (pending): " "$file"
+  printf "\e[1m%s\e[0m (pending): " "$(basename "$file")"
   if ruby -I"$WASMINNA_PATH"/lib "$WASMINNA_PATH"/run_wast.rb "$WASM_SPEC_PATH"/test/core/$file; then
     printf "\e[31merror: pending test passed\e[0m\n"
     exit 1

--- a/test/execute_function_test.rb
+++ b/test/execute_function_test.rb
@@ -93,8 +93,6 @@ raise unless 10.times.map { mod.even(_1) } == [44, 99, 44, 99, 44, 99, 44, 99, 4
 raise unless 10.times.map { mod.odd(_1) } == [99, 44, 99, 44, 99, 44, 99, 44, 99, 44]
 print "\e[32m.\e[0m"
 
-puts
-
 BEGIN {
   require 'wasminna/ast_parser'
   require 'wasminna/float'
@@ -164,4 +162,8 @@ BEGIN {
       end
     end
   end
+}
+
+END {
+  puts
 }

--- a/test/execute_function_test.rb
+++ b/test/execute_function_test.rb
@@ -1,91 +1,86 @@
-source =
-  <<~eos
-    (module
-      (func (export "add") (param i32 i32) (result i32)
-        (i32.add (local.get 0) (local.get 1))
-      )
+source = <<'--'
+  (module
+    (func (export "add") (param i32 i32) (result i32)
+      (i32.add (local.get 0) (local.get 1))
     )
-  eos
+  )
+--
 mod = Wasminna.load(source)
 raise unless mod.add(2, 3) == 5
 print "\e[32m.\e[0m"
 
-source =
-  <<~eos
-    (module
-      (func (export "dup") (param i32) (result i32 i32)
-        local.get 0
-        local.get 0
-      )
+source = <<'--'
+  (module
+    (func (export "dup") (param i32) (result i32 i32)
+      local.get 0
+      local.get 0
     )
-  eos
+  )
+--
 mod = Wasminna.load(source)
 raise unless mod.dup(6) == [6, 6]
 print "\e[32m.\e[0m"
 
-source =
-  <<~eos
-    (module
-      (func (export "add") (param f32 f32) (result f32)
-        (f32.add (local.get 0) (local.get 1))
-      )
+source = <<'--'
+  (module
+    (func (export "add") (param f32 f32) (result f32)
+      (f32.add (local.get 0) (local.get 1))
     )
-  eos
+  )
+--
 mod = Wasminna.load(source)
 raise unless mod.add(2.0, 3.0) == 5.0
 print "\e[32m.\e[0m"
 
-source =
-  <<~eos
-    (module
-      (func (export "add") (param i32 i32) (result i32)
-        (i32.add (local.get 0) (local.get 1))
-      )
+source = <<'--'
+  (module
+    (func (export "add") (param i32 i32) (result i32)
+      (i32.add (local.get 0) (local.get 1))
     )
-  eos
+  )
+--
 mod = Wasminna.load(source)
 raise unless mod.add(-2, 3) == 1
 print "\e[32m.\e[0m"
 
-source =
-  <<-eos
-    (func $fac (export "fac") (param i64) (result i64)
-      (if (result i64) (i64.eqz (local.get 0))
-        (then (i64.const 1))
-        (else
-          (i64.mul
-            (local.get 0)
-            (call $fac (i64.sub (local.get 0) (i64.const 1)))
-          )
+source = <<'--'
+  (func $fac (export "fac") (param i64) (result i64)
+    (if (result i64) (i64.eqz (local.get 0))
+      (then (i64.const 1))
+      (else
+        (i64.mul
+          (local.get 0)
+          (call $fac (i64.sub (local.get 0) (i64.const 1)))
         )
       )
     )
+  )
 
-    (func $fib (export "fib") (param i64) (result i64)
-      (if (result i64) (i64.le_u (local.get 0) (i64.const 1))
-        (then (i64.const 1))
-        (else
-          (i64.add
-            (call $fib (i64.sub (local.get 0) (i64.const 2)))
-            (call $fib (i64.sub (local.get 0) (i64.const 1)))
-          )
+  (func $fib (export "fib") (param i64) (result i64)
+    (if (result i64) (i64.le_u (local.get 0) (i64.const 1))
+      (then (i64.const 1))
+      (else
+        (i64.add
+          (call $fib (i64.sub (local.get 0) (i64.const 2)))
+          (call $fib (i64.sub (local.get 0) (i64.const 1)))
         )
       )
     )
+  )
 
-    (func $even (export "even") (param i64) (result i32)
-      (if (result i32) (i64.eqz (local.get 0))
-        (then (i32.const 44))
-        (else (call $odd (i64.sub (local.get 0) (i64.const 1))))
-      )
+  (func $even (export "even") (param i64) (result i32)
+    (if (result i32) (i64.eqz (local.get 0))
+      (then (i32.const 44))
+      (else (call $odd (i64.sub (local.get 0) (i64.const 1))))
     )
-    (func $odd (export "odd") (param i64) (result i32)
-      (if (result i32) (i64.eqz (local.get 0))
-        (then (i32.const 99))
-        (else (call $even (i64.sub (local.get 0) (i64.const 1))))
-      )
+  )
+  (func $odd (export "odd") (param i64) (result i32)
+    (if (result i32) (i64.eqz (local.get 0))
+      (then (i32.const 99))
+      (else (call $even (i64.sub (local.get 0) (i64.const 1))))
     )
-  eos
+  )
+--
 mod = Wasminna.load(source)
 raise unless 10.times.map { mod.fac(_1) } == [1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880]
 raise unless 10.times.map { mod.fib(_1) } == [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]

--- a/test/float_test.rb
+++ b/test/float_test.rb
@@ -1,13 +1,13 @@
-assert_float_encoding 3141592653589793r / 10 ** 15, 0x4049_0fdb, bits: 32
-assert_float_encoding 0x7fffff4000000001r, 0x5eff_ffff, bits: 32
-assert_float_encoding 0r, 0x0000_0000, bits: 32
-assert_float_encoding 0x7fffffffr, 0x4f00_0000, bits: 32
+assert_encode 3141592653589793r / 10 ** 15, 0x4049_0fdb, bits: 32
+assert_encode 0x7fffff4000000001r, 0x5eff_ffff, bits: 32
+assert_encode 0r, 0x0000_0000, bits: 32
+assert_encode 0x7fffffffr, 0x4f00_0000, bits: 32
 
-assert_float_encoding 1r, 0x3ff0_0000_0000_0000, bits: 64
-assert_float_encoding 6723256985364377r, 0x4337_e2c4_4058_a799, bits: 64
+assert_encode 1r, 0x3ff0_0000_0000_0000, bits: 64
+assert_encode 6723256985364377r, 0x4337_e2c4_4058_a799, bits: 64
 
-assert_float_decoding 0x0000_0000, Wasminna::Float::Zero.new(sign: Wasminna::Sign::PLUS), bits: 32
-assert_float_decoding 0x0000_0001, Wasminna::Float::Finite.new(rational: 1r / 2 ** 149), bits: 32
+assert_decode 0x0000_0000, Wasminna::Float::Zero.new(sign: Wasminna::Sign::PLUS), bits: 32
+assert_decode 0x0000_0001, Wasminna::Float::Finite.new(rational: 1r / 2 ** 149), bits: 32
 
 BEGIN {
   require 'wasminna/float'
@@ -16,7 +16,7 @@ BEGIN {
   require 'wasminna/float/zero'
   require 'wasminna/sign'
 
-  def assert_float_encoding(input, expected, bits:)
+  def assert_encode(input, expected, bits:)
     format = Wasminna::Float::Format.for(bits:)
     actual = Wasminna::Float::Finite.new(rational: input).encode(format:)
     if actual == expected
@@ -26,7 +26,7 @@ BEGIN {
     end
   end
 
-  def assert_float_decoding(input, expected, bits:)
+  def assert_decode(input, expected, bits:)
     format = Wasminna::Float::Format.for(bits:)
     actual = Wasminna::Float.decode(input, format:)
     if actual == expected

--- a/test/float_test.rb
+++ b/test/float_test.rb
@@ -1,42 +1,42 @@
-require 'wasminna/float'
-require 'wasminna/float/finite'
-require 'wasminna/float/format'
-require 'wasminna/float/zero'
-require 'wasminna/sign'
+assert_float_encoding 0x4049_0fdb, 3141592653589793r / 10 ** 15, bits: 32
+assert_float_encoding 0x5eff_ffff, 0x7fffff4000000001r, bits: 32
+assert_float_encoding 0x0000_0000, 0r, bits: 32
+assert_float_encoding 0x4f00_0000, 0x7fffffffr, bits: 32
 
-def main
-  assert_float_encoding 0x4049_0fdb, 3141592653589793r / 10 ** 15, bits: 32
-  assert_float_encoding 0x5eff_ffff, 0x7fffff4000000001r, bits: 32
-  assert_float_encoding 0x0000_0000, 0r, bits: 32
-  assert_float_encoding 0x4f00_0000, 0x7fffffffr, bits: 32
+assert_float_encoding 0x3ff0_0000_0000_0000, 1r, bits: 64
+assert_float_encoding 0x4337_e2c4_4058_a799, 6723256985364377r, bits: 64
 
-  assert_float_encoding 0x3ff0_0000_0000_0000, 1r, bits: 64
-  assert_float_encoding 0x4337_e2c4_4058_a799, 6723256985364377r, bits: 64
+assert_float_decoding Wasminna::Float::Zero.new(sign: Wasminna::Sign::PLUS), 0x0000_0000, bits: 32
+assert_float_decoding Wasminna::Float::Finite.new(rational: 1r / 2 ** 149), 0x0000_0001, bits: 32
 
-  assert_float_decoding Wasminna::Float::Zero.new(sign: Wasminna::Sign::PLUS), 0x0000_0000, bits: 32
-  assert_float_decoding Wasminna::Float::Finite.new(rational: 1r / 2 ** 149), 0x0000_0001, bits: 32
+BEGIN {
+  require 'wasminna/float'
+  require 'wasminna/float/finite'
+  require 'wasminna/float/format'
+  require 'wasminna/float/zero'
+  require 'wasminna/sign'
 
+  def assert_float_encoding(expected, rational, bits:)
+    format = Wasminna::Float::Format.for(bits:)
+    actual = Wasminna::Float::Finite.new(rational:).encode(format:)
+    if actual == expected
+      print "\e[32m.\e[0m"
+    else
+      raise "expected #{expected}, got #{actual}"
+    end
+  end
+
+  def assert_float_decoding(expected, encoded, bits:)
+    format = Wasminna::Float::Format.for(bits:)
+    actual = Wasminna::Float.decode(encoded, format:)
+    if actual == expected
+      print "\e[32m.\e[0m"
+    else
+      raise "expected #{expected}, got #{actual}"
+    end
+  end
+}
+
+END {
   puts
-end
-
-def assert_float_encoding(expected, rational, bits:)
-  format = Wasminna::Float::Format.for(bits:)
-  actual = Wasminna::Float::Finite.new(rational:).encode(format:)
-  if actual == expected
-    print "\e[32m.\e[0m"
-  else
-    raise "expected #{expected}, got #{actual}"
-  end
-end
-
-def assert_float_decoding(expected, encoded, bits:)
-  format = Wasminna::Float::Format.for(bits:)
-  actual = Wasminna::Float.decode(encoded, format:)
-  if actual == expected
-    print "\e[32m.\e[0m"
-  else
-    raise "expected #{expected}, got #{actual}"
-  end
-end
-
-main
+}

--- a/test/float_test.rb
+++ b/test/float_test.rb
@@ -1,13 +1,13 @@
-assert_float_encoding 0x4049_0fdb, 3141592653589793r / 10 ** 15, bits: 32
-assert_float_encoding 0x5eff_ffff, 0x7fffff4000000001r, bits: 32
-assert_float_encoding 0x0000_0000, 0r, bits: 32
-assert_float_encoding 0x4f00_0000, 0x7fffffffr, bits: 32
+assert_float_encoding 3141592653589793r / 10 ** 15, 0x4049_0fdb, bits: 32
+assert_float_encoding 0x7fffff4000000001r, 0x5eff_ffff, bits: 32
+assert_float_encoding 0r, 0x0000_0000, bits: 32
+assert_float_encoding 0x7fffffffr, 0x4f00_0000, bits: 32
 
-assert_float_encoding 0x3ff0_0000_0000_0000, 1r, bits: 64
-assert_float_encoding 0x4337_e2c4_4058_a799, 6723256985364377r, bits: 64
+assert_float_encoding 1r, 0x3ff0_0000_0000_0000, bits: 64
+assert_float_encoding 6723256985364377r, 0x4337_e2c4_4058_a799, bits: 64
 
-assert_float_decoding Wasminna::Float::Zero.new(sign: Wasminna::Sign::PLUS), 0x0000_0000, bits: 32
-assert_float_decoding Wasminna::Float::Finite.new(rational: 1r / 2 ** 149), 0x0000_0001, bits: 32
+assert_float_decoding 0x0000_0000, Wasminna::Float::Zero.new(sign: Wasminna::Sign::PLUS), bits: 32
+assert_float_decoding 0x0000_0001, Wasminna::Float::Finite.new(rational: 1r / 2 ** 149), bits: 32
 
 BEGIN {
   require 'wasminna/float'
@@ -16,9 +16,9 @@ BEGIN {
   require 'wasminna/float/zero'
   require 'wasminna/sign'
 
-  def assert_float_encoding(expected, rational, bits:)
+  def assert_float_encoding(input, expected, bits:)
     format = Wasminna::Float::Format.for(bits:)
-    actual = Wasminna::Float::Finite.new(rational:).encode(format:)
+    actual = Wasminna::Float::Finite.new(rational: input).encode(format:)
     if actual == expected
       print "\e[32m.\e[0m"
     else
@@ -26,9 +26,9 @@ BEGIN {
     end
   end
 
-  def assert_float_decoding(expected, encoded, bits:)
+  def assert_float_decoding(input, expected, bits:)
     format = Wasminna::Float::Format.for(bits:)
-    actual = Wasminna::Float.decode(encoded, format:)
+    actual = Wasminna::Float.decode(input, format:)
     if actual == expected
       print "\e[32m.\e[0m"
     else

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -4,7 +4,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [['module', '$mymodule', ['func', %w[import "spectest" "print_i32"], %w[param i32]]]]
@@ -13,7 +13,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [['module', ['func', '$myfunction', %w[import "spectest" "print_i32"], %w[param i32]]]]
@@ -22,7 +22,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [['module', ['table', %w[import "spectest" "table"], *%w[0 funcref]]]]
@@ -31,7 +31,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [['module', ['memory', %w[import "spectest" "memory"], *%w[1 2]]]]
@@ -40,7 +40,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [['module', ['global', %w[import "spectest" "global_i32"], 'i32']]]
@@ -49,7 +49,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -67,7 +67,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -88,7 +88,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -108,7 +108,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -128,7 +128,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -146,7 +146,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -166,7 +166,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -188,7 +188,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -205,7 +205,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -222,7 +222,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -239,7 +239,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -256,7 +256,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -281,7 +281,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -308,7 +308,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = [
@@ -321,7 +321,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 BEGIN {

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -1,5 +1,13 @@
-input = [['module', ['func', %w[import "spectest" "print_i32"], %w[param i32]]]]
-expected = [['module', [*%w[import "spectest" "print_i32"], ['func', %w[param i32]]]]]
+input = parse <<'--'
+  (module
+    (func (import "spectest" "print_i32") (param i32))
+  )
+--
+expected = parse <<'--'
+  (module
+    (import "spectest" "print_i32" (func (param i32)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -7,8 +15,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [['module', '$mymodule', ['func', %w[import "spectest" "print_i32"], %w[param i32]]]]
-expected = [['module', '$mymodule', [*%w[import "spectest" "print_i32"], ['func', %w[param i32]]]]]
+input = parse <<'--'
+  (module $mymodule
+    (func (import "spectest" "print_i32") (param i32))
+  )
+--
+expected = parse <<'--'
+  (module $mymodule
+    (import "spectest" "print_i32" (func (param i32)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -16,8 +32,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [['module', ['func', '$myfunction', %w[import "spectest" "print_i32"], %w[param i32]]]]
-expected = [['module', [*%w[import "spectest" "print_i32"], ['func', '$myfunction', %w[param i32]]]]]
+input = parse <<'--'
+  (module
+    (func $myfunction (import "spectest" "print_i32") (param i32))
+  )
+--
+expected = parse <<'--'
+  (module
+    (import "spectest" "print_i32" (func $myfunction (param i32)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -25,8 +49,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [['module', ['table', %w[import "spectest" "table"], *%w[0 funcref]]]]
-expected = [['module', [*%w[import "spectest" "table"], ['table', *%w[0 funcref]]]]]
+input = parse <<'--'
+  (module
+    (table (import "spectest" "table") 0 funcref)
+  )
+--
+expected = parse <<'--'
+  (module
+    (import "spectest" "table" (table 0 funcref))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -34,8 +66,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [['module', ['memory', %w[import "spectest" "memory"], *%w[1 2]]]]
-expected = [['module', [*%w[import "spectest" "memory"], ['memory', *%w[1 2]]]]]
+input = parse <<'--'
+  (module
+    (memory (import "spectest" "memory") 1 2)
+  )
+--
+expected = parse <<'--'
+  (module
+    (import "spectest" "memory" (memory 1 2))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -43,8 +83,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [['module', ['global', %w[import "spectest" "global_i32"], 'i32']]]
-expected = [['module', [*%w[import "spectest" "global_i32"], %w[global i32]]]]
+input = parse <<'--'
+  (module
+    (global (import "spectest" "global_i32") i32)
+  )
+--
+expected = parse <<'--'
+  (module
+    (import "spectest" "global_i32" (global i32))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -52,17 +100,17 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['func', %w[export "i32.test"], %w[result i32], ['return', %w[i32.const 0x0bAdD00D]]]
-  ]
-]
-expected = [
-  ['module',
-    [*%w[export "i32.test"], %w[func $__fresh_0]],
-    [*%w[func $__fresh_0], %w[result i32], ['return', %w[i32.const 0x0bAdD00D]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
+  )
+--
+expected = parse <<'--'
+  (module
+    (export "i32.test" (func $__fresh_0))
+    (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -70,20 +118,20 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['func', %w[export "i32.test"], %w[result i32], ['return', %w[i32.const 0x0bAdD00D]]],
-    ['func', %w[export "i32.umax"], %w[result i32], ['return', %w[i32.const 0xffffffff]]]
-  ]
-]
-expected = [
-  ['module',
-    [*%w[export "i32.test"], %w[func $__fresh_0]],
-    [*%w[func $__fresh_0], %w[result i32], ['return', %w[i32.const 0x0bAdD00D]]],
-    [*%w[export "i32.umax"], %w[func $__fresh_1]],
-    [*%w[func $__fresh_1], %w[result i32], ['return', %w[i32.const 0xffffffff]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
+    (func (export "i32.umax") (result i32) (return (i32.const 0xffffffff)))
+  )
+--
+expected = parse <<'--'
+  (module
+    (export "i32.test" (func $__fresh_0))
+    (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+    (export "i32.umax" (func $__fresh_1))
+    (func $__fresh_1 (result i32) (return (i32.const 0xffffffff)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -91,19 +139,25 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-   ['func', %w[export "i32.test1"], %w[export "i32.test2"], %w[export "i32.test3"], %w[result i32], ['return', %w[i32.const 0x0bAdD00D]]]
-  ]
-]
-expected = [
-  ['module',
-    [*%w[export "i32.test1"], %w[func $__fresh_0]],
-    [*%w[export "i32.test2"], %w[func $__fresh_0]],
-    [*%w[export "i32.test3"], %w[func $__fresh_0]],
-    [*%w[func $__fresh_0], %w[result i32], ['return', %w[i32.const 0x0bAdD00D]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func
+      (export "i32.test1")
+      (export "i32.test2")
+      (export "i32.test3")
+      (result i32)
+      (return (i32.const 0x0bAdD00D))
+    )
+  )
+--
+expected = parse <<'--'
+  (module
+    (export "i32.test1" (func $__fresh_0))
+    (export "i32.test2" (func $__fresh_0))
+    (export "i32.test3" (func $__fresh_0))
+    (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -111,19 +165,25 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-   ['func', %w[export "i32.test1"], %w[export "i32.test2"], %w[export "i32.test3"], %w[import "mymodule" "bad_dude"], %w[result i32]]
-  ]
-]
-expected = [
-  ['module',
-    [*%w[export "i32.test1"], %w[func $__fresh_0]],
-    [*%w[export "i32.test2"], %w[func $__fresh_0]],
-    [*%w[export "i32.test3"], %w[func $__fresh_0]],
-    [*%w[import "mymodule" "bad_dude"], [*%w[func $__fresh_0], %w[result i32]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func
+      (export "i32.test1")
+      (export "i32.test2")
+      (export "i32.test3")
+      (import "mymodule" "bad_dude")
+      (result i32)
+    )
+  )
+--
+expected = parse <<'--'
+  (module
+    (export "i32.test1" (func $__fresh_0))
+    (export "i32.test2" (func $__fresh_0))
+    (export "i32.test3" (func $__fresh_0))
+    (import "mymodule" "bad_dude" (func $__fresh_0 (result i32)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -131,17 +191,17 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['table', %w[export "a"], *%w[0 1 funcref]]
-  ]
-]
-expected = [
-  ['module',
-    [*%w[export "a"], %w[table $__fresh_0]],
-    %w[table $__fresh_0 0 1 funcref]
-  ]
-]
+input = parse <<'--'
+  (module
+    (table (export "a") 0 1 funcref)
+  )
+--
+expected = parse <<'--'
+  (module
+    (export "a" (table $__fresh_0))
+    (table $__fresh_0 0 1 funcref)
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -149,19 +209,19 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  %w[func],
-  %w[memory 0],
-  ['func', %w[export "f"]]
-]
-expected = [
-  ['module',
-    %w[func],
-    %w[memory 0],
-    [*%w[export "f"], %w[func $__fresh_0]],
-    %w[func $__fresh_0]
-  ]
-]
+input = parse <<'--'
+  (func)
+  (memory 0)
+  (func (export "f"))
+--
+expected = parse <<'--'
+  (module
+    (func)
+    (memory 0)
+    (export "f" (func $__fresh_0))
+    (func $__fresh_0)
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -169,21 +229,21 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  %w[func],
-  %w[memory 0],
-  ['func', %w[export "f"]],
-  %w[invoke "f"]
-]
-expected = [
-  ['module',
-    %w[func],
-    %w[memory 0],
-    [*%w[export "f"], %w[func $__fresh_0]],
-    %w[func $__fresh_0]
-  ],
-  %w[invoke "f"]
-]
+input = parse <<'--'
+  (func)
+  (memory 0)
+  (func (export "f"))
+  (invoke "f")
+--
+expected = parse <<'--'
+  (module
+    (func)
+    (memory 0)
+    (export "f" (func $__fresh_0))
+    (func $__fresh_0)
+  )
+  (invoke "f")
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -191,16 +251,20 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['func', %w[result i32], %w[local i32 f64 funcref], ['return', %w[i32.const 0x0bAdD00D]]]
-  ]
-]
-expected = [
-  ['module',
-    ['func', %w[result i32], %w[local i32], %w[local f64], %w[local funcref], ['return', %w[i32.const 0x0bAdD00D]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func (result i32) (local i32 f64 funcref)
+      (return (i32.const 0x0bAdD00D))
+    )
+  )
+--
+expected = parse <<'--'
+  (module
+    (func (result i32) (local i32) (local f64) (local funcref)
+      (return (i32.const 0x0bAdD00D))
+    )
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -208,16 +272,22 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-   ['func', %w[param i32 i64], %w[result i64 i32], %w[i64.const 1], %w[i32.const 2]]
-  ]
-]
-expected = [
-  ['module',
-   ['func', %w[param i32], %w[param i64], %w[result i64], %w[result i32], %w[i64.const 1], %w[i32.const 2]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func (param i32 i64) (result i64 i32)
+      (i64.const 1)
+      (i32.const 2)
+    )
+  )
+--
+expected = parse <<'--'
+  (module
+    (func (param i32) (param i64) (result i64) (result i32)
+      (i64.const 1)
+      (i32.const 2)
+    )
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -225,16 +295,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['type', ['func', %w[param i32 i64], %w[result f32 f64]]]
-  ]
-]
-expected = [
-  ['module',
-    ['type', ['func', %w[param i32], %w[param i64], %w[result f32], %w[result f64]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (type (func (param i32 i64) (result f32 f64)))
+  )
+--
+expected = parse <<'--'
+  (module
+    (type (func (param i32) (param i64) (result f32) (result f64)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -242,16 +312,16 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['import', 'a', 'b', ['func', %w[param i32 i64], %w[result f32 f64]]]
-  ]
-]
-expected = [
-  ['module',
-    ['import', 'a', 'b', ['func', %w[param i32], %w[param i64], %w[result f32], %w[result f64]]]
-  ]
-]
+input = parse <<'--'
+  (module
+    (import a b (func (param i32 i64) (result f32 f64)))
+  )
+--
+expected = parse <<'--'
+  (module
+    (import a b (func (param i32) (param i64) (result f32) (result f64)))
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -259,24 +329,26 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['func',
-      ['block', %w[param i32 i32], %w[result i32 i32],
-        %w[i32 add], %w[i32.const 1]
-      ]
-    ]
-  ]
-]
-expected = [
-  ['module',
-    ['func',
-      ['block', %w[param i32], %w[param i32], %w[result i32], %w[result i32],
-        %w[i32 add], %w[i32.const 1]
-      ]
-    ]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func
+      (block (param i32 i32) (result i32 i32)
+        (i32 add)
+        (i32.const 1)
+      )
+    )
+  )
+--
+expected = parse <<'--'
+  (module
+    (func
+      (block (param i32) (param i32) (result i32) (result i32)
+        (i32 add)
+        (i32.const 1)
+      )
+    )
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -284,26 +356,26 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  ['module',
-    ['func',
-      ['call_indirect',
-        %w[param i64], %w[param], %w[param f64 i32 i64],
-        %w[result f32 f64], %w[result i32]
-      ]
-    ]
-  ]
-]
-expected = [
-  ['module',
-    ['func',
-      ['call_indirect',
-        %w[param i64], %w[param f64], %w[param i32], %w[param i64],
-        %w[result f32], %w[result f64], %w[result i32]
-      ]
-    ]
-  ]
-]
+input = parse <<'--'
+  (module
+    (func
+      (call_indirect
+        (param i64) (param) (param f64 i32 i64)
+        (result f32 f64) (result i32)
+      )
+    )
+  )
+--
+expected = parse <<'--'
+  (module
+    (func
+      (call_indirect
+        (param i64) (param f64) (param i32) (param i64)
+        (result f32) (result f64) (result i32)
+      )
+    )
+  )
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -311,12 +383,12 @@ else
   raise "expected #{expected}, got #{actual}"
 end
 
-input = [
-  %w[module $M2 binary "\00asm" "\01\00\00\00"]
-]
-expected = [
-  %w[module $M2 binary "\00asm" "\01\00\00\00"]
-]
+input = parse <<'--'
+  (module $M2 binary "\00asm" "\01\00\00\00")
+--
+expected = parse <<'--'
+  (module $M2 binary "\00asm" "\01\00\00\00")
+--
 actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
@@ -326,6 +398,11 @@ end
 
 BEGIN {
   require 'wasminna/preprocessor'
+  require 'wasminna/s_expression_parser'
+
+  def parse(string)
+    Wasminna::SExpressionParser.new.parse(string)
+  end
 }
 
 END {

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -1,5 +1,3 @@
-require 'wasminna/preprocessor'
-
 input = [['module', ['func', %w[import "spectest" "print_i32"], %w[param i32]]]]
 expected = [['module', [*%w[import "spectest" "print_i32"], ['func', %w[param i32]]]]]
 actual = Wasminna::Preprocessor.new.process_script(input)
@@ -326,4 +324,10 @@ else
   raise actual.inspect unless actual == expected
 end
 
-puts
+BEGIN {
+  require 'wasminna/preprocessor'
+}
+
+END {
+  puts
+}

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -1,130 +1,80 @@
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func (import "spectest" "print_i32") (param i32))
   )
 --
-expected = parse <<'--'
   (module
     (import "spectest" "print_i32" (func (param i32)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module $mymodule
     (func (import "spectest" "print_i32") (param i32))
   )
 --
-expected = parse <<'--'
   (module $mymodule
     (import "spectest" "print_i32" (func (param i32)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func $myfunction (import "spectest" "print_i32") (param i32))
   )
 --
-expected = parse <<'--'
   (module
     (import "spectest" "print_i32" (func $myfunction (param i32)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (table (import "spectest" "table") 0 funcref)
   )
 --
-expected = parse <<'--'
   (module
     (import "spectest" "table" (table 0 funcref))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (memory (import "spectest" "memory") 1 2)
   )
 --
-expected = parse <<'--'
   (module
     (import "spectest" "memory" (memory 1 2))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (global (import "spectest" "global_i32") i32)
   )
 --
-expected = parse <<'--'
   (module
     (import "spectest" "global_i32" (global i32))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
   )
 --
-expected = parse <<'--'
   (module
     (export "i32.test" (func $__fresh_0))
     (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
     (func (export "i32.umax") (result i32) (return (i32.const 0xffffffff)))
   )
 --
-expected = parse <<'--'
   (module
     (export "i32.test" (func $__fresh_0))
     (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
@@ -132,14 +82,8 @@ expected = parse <<'--'
     (func $__fresh_1 (result i32) (return (i32.const 0xffffffff)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func
       (export "i32.test1")
@@ -150,7 +94,6 @@ input = parse <<'--'
     )
   )
 --
-expected = parse <<'--'
   (module
     (export "i32.test1" (func $__fresh_0))
     (export "i32.test2" (func $__fresh_0))
@@ -158,14 +101,8 @@ expected = parse <<'--'
     (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func
       (export "i32.test1")
@@ -176,7 +113,6 @@ input = parse <<'--'
     )
   )
 --
-expected = parse <<'--'
   (module
     (export "i32.test1" (func $__fresh_0))
     (export "i32.test2" (func $__fresh_0))
@@ -184,37 +120,23 @@ expected = parse <<'--'
     (import "mymodule" "bad_dude" (func $__fresh_0 (result i32)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (table (export "a") 0 1 funcref)
   )
 --
-expected = parse <<'--'
   (module
     (export "a" (table $__fresh_0))
     (table $__fresh_0 0 1 funcref)
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (func)
   (memory 0)
   (func (export "f"))
 --
-expected = parse <<'--'
   (module
     (func)
     (memory 0)
@@ -222,20 +144,13 @@ expected = parse <<'--'
     (func $__fresh_0)
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (func)
   (memory 0)
   (func (export "f"))
   (invoke "f")
 --
-expected = parse <<'--'
   (module
     (func)
     (memory 0)
@@ -244,35 +159,22 @@ expected = parse <<'--'
   )
   (invoke "f")
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func (result i32) (local i32 f64 funcref)
       (return (i32.const 0x0bAdD00D))
     )
   )
 --
-expected = parse <<'--'
   (module
     (func (result i32) (local i32) (local f64) (local funcref)
       (return (i32.const 0x0bAdD00D))
     )
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func (param i32 i64) (result i64 i32)
       (i64.const 1)
@@ -280,7 +182,6 @@ input = parse <<'--'
     )
   )
 --
-expected = parse <<'--'
   (module
     (func (param i32) (param i64) (result i64) (result i32)
       (i64.const 1)
@@ -288,48 +189,28 @@ expected = parse <<'--'
     )
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (type (func (param i32 i64) (result f32 f64)))
   )
 --
-expected = parse <<'--'
   (module
     (type (func (param i32) (param i64) (result f32) (result f64)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (import a b (func (param i32 i64) (result f32 f64)))
   )
 --
-expected = parse <<'--'
   (module
     (import a b (func (param i32) (param i64) (result f32) (result f64)))
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func
       (block (param i32 i32) (result i32 i32)
@@ -339,7 +220,6 @@ input = parse <<'--'
     )
   )
 --
-expected = parse <<'--'
   (module
     (func
       (block (param i32) (param i32) (result i32) (result i32)
@@ -349,14 +229,8 @@ expected = parse <<'--'
     )
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module
     (func
       (call_indirect
@@ -366,7 +240,6 @@ input = parse <<'--'
     )
   )
 --
-expected = parse <<'--'
   (module
     (func
       (call_indirect
@@ -376,25 +249,12 @@ expected = parse <<'--'
     )
   )
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
-input = parse <<'--'
+assert_preprocess <<'--', <<'--'
   (module $M2 binary "\00asm" "\01\00\00\00")
 --
-expected = parse <<'--'
   (module $M2 binary "\00asm" "\01\00\00\00")
 --
-actual = Wasminna::Preprocessor.new.process_script(input)
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
 
 BEGIN {
   require 'wasminna/preprocessor'
@@ -402,6 +262,18 @@ BEGIN {
 
   def parse(string)
     Wasminna::SExpressionParser.new.parse(string)
+  end
+
+  def assert_preprocess(input, expected)
+    input = parse(input)
+    expected = parse(expected)
+    actual = Wasminna::Preprocessor.new.process_script(input)
+
+    if actual == expected
+      print "\e[32m.\e[0m"
+    else
+      raise "expected #{expected}, got #{actual}"
+    end
   end
 }
 

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -4,7 +4,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [['module', '$mymodule', ['func', %w[import "spectest" "print_i32"], %w[param i32]]]]
@@ -13,7 +13,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [['module', ['func', '$myfunction', %w[import "spectest" "print_i32"], %w[param i32]]]]
@@ -22,7 +22,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [['module', ['table', %w[import "spectest" "table"], *%w[0 funcref]]]]
@@ -31,7 +31,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [['module', ['memory', %w[import "spectest" "memory"], *%w[1 2]]]]
@@ -40,7 +40,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [['module', ['global', %w[import "spectest" "global_i32"], 'i32']]]
@@ -49,7 +49,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -67,7 +67,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -88,7 +88,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -108,7 +108,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -128,7 +128,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -146,7 +146,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -166,7 +166,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -188,7 +188,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -205,7 +205,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -222,7 +222,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -239,7 +239,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -256,7 +256,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -281,7 +281,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -308,7 +308,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = [
@@ -321,7 +321,7 @@ actual = Wasminna::Preprocessor.new.process_script(input)
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 BEGIN {

--- a/test/s_expression_parser_test.rb
+++ b/test/s_expression_parser_test.rb
@@ -1,5 +1,3 @@
-require 'wasminna/s_expression_parser'
-
 input = 'hello'
 expected = ['hello']
 actual = Wasminna::SExpressionParser.new.parse(input).entries
@@ -144,4 +142,10 @@ else
   raise actual.inspect unless actual == expected
 end
 
-puts
+BEGIN {
+  require 'wasminna/s_expression_parser'
+}
+
+END {
+  puts
+}

--- a/test/s_expression_parser_test.rb
+++ b/test/s_expression_parser_test.rb
@@ -1,149 +1,31 @@
-input = 'hello'
-expected = ['hello']
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(hello)'
-expected = [['hello']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(hello world)'
-expected = [['hello', 'world']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '((hello goodbye) world)'
-expected = [[['hello', 'goodbye'], 'world']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = "(module\n  (func (nop))\n)"
-expected = [['module', ['func', ['nop']]]]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = "(module\n  (func(nop))\n)"
-expected = [['module', ['func', ['nop']]]]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = "(module\n  (func (nop)nop)\n)"
-expected = [['module', ['func', ['nop'], 'nop']]]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(module) (module)'
-expected = [['module'], ['module']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = ";; Tokens can be delimited by parentheses\n\n(module\n  (func(nop))\n)"
-expected = [['module', ['func', ['nop']]]]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = "(module\n  (func;;bla\n  )\n)"
-expected = [['module', ['func']]]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '"(hello world) ;; comment"'
-expected = ['"(hello world) ;; comment"']
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '"hello \" world"'
-expected = ['"hello \" world"']
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(hello (; cruel ;) world)'
-expected = [['hello', 'world']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(hello (; this; is; ( totally; ); fine ;) world)'
-expected = [['hello', 'world']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(hello (; cruel (; very cruel ;) extremely cruel ;) world)'
-expected = [['hello', 'world']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
-
-input = '(hello (; cruel ;) happy (; terrible ;) world)'
-expected = [['hello', 'happy', 'world']]
-actual = Wasminna::SExpressionParser.new.parse(input).entries
-if actual == expected
-  print "\e[32m.\e[0m"
-else
-  raise "expected #{expected}, got #{actual}"
-end
+assert_parse 'hello', ['hello']
+assert_parse '(hello)', [['hello']]
+assert_parse '(hello world)', [['hello', 'world']]
+assert_parse '((hello goodbye) world)', [[['hello', 'goodbye'], 'world']]
+assert_parse "(module\n  (func (nop))\n)", [['module', ['func', ['nop']]]]
+assert_parse "(module\n  (func(nop))\n)", [['module', ['func', ['nop']]]]
+assert_parse "(module\n  (func (nop)nop)\n)", [['module', ['func', ['nop'], 'nop']]]
+assert_parse '(module) (module)', [['module'], ['module']]
+assert_parse ";; Tokens can be delimited by parentheses\n\n(module\n  (func(nop))\n)", [['module', ['func', ['nop']]]]
+assert_parse "(module\n  (func;;bla\n  )\n)", [['module', ['func']]]
+assert_parse '"(hello world) ;; comment"', ['"(hello world) ;; comment"']
+assert_parse '"hello \" world"', ['"hello \" world"']
+assert_parse '(hello (; cruel ;) world)', [['hello', 'world']]
+assert_parse '(hello (; this; is; ( totally; ); fine ;) world)', [['hello', 'world']]
+assert_parse '(hello (; cruel (; very cruel ;) extremely cruel ;) world)', [['hello', 'world']]
+assert_parse '(hello (; cruel ;) happy (; terrible ;) world)', [['hello', 'happy', 'world']]
 
 BEGIN {
   require 'wasminna/s_expression_parser'
+
+  def assert_parse(input, expected)
+    actual = Wasminna::SExpressionParser.new.parse(input)
+    if actual == expected
+      print "\e[32m.\e[0m"
+    else
+      raise "expected #{expected}, got #{actual}"
+    end
+  end
 }
 
 END {

--- a/test/s_expression_parser_test.rb
+++ b/test/s_expression_parser_test.rb
@@ -4,7 +4,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(hello)'
@@ -13,7 +13,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(hello world)'
@@ -22,7 +22,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '((hello goodbye) world)'
@@ -31,7 +31,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = "(module\n  (func (nop))\n)"
@@ -40,7 +40,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = "(module\n  (func(nop))\n)"
@@ -49,7 +49,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = "(module\n  (func (nop)nop)\n)"
@@ -58,7 +58,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(module) (module)'
@@ -67,7 +67,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = ";; Tokens can be delimited by parentheses\n\n(module\n  (func(nop))\n)"
@@ -76,7 +76,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = "(module\n  (func;;bla\n  )\n)"
@@ -85,7 +85,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '"(hello world) ;; comment"'
@@ -94,7 +94,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '"hello \" world"'
@@ -103,7 +103,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(hello (; cruel ;) world)'
@@ -112,7 +112,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(hello (; this; is; ( totally; ); fine ;) world)'
@@ -121,7 +121,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(hello (; cruel (; very cruel ;) extremely cruel ;) world)'
@@ -130,7 +130,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 input = '(hello (; cruel ;) happy (; terrible ;) world)'
@@ -139,7 +139,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect unless actual == expected
+  raise actual.inspect
 end
 
 BEGIN {

--- a/test/s_expression_parser_test.rb
+++ b/test/s_expression_parser_test.rb
@@ -4,7 +4,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(hello)'
@@ -13,7 +13,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(hello world)'
@@ -22,7 +22,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '((hello goodbye) world)'
@@ -31,7 +31,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = "(module\n  (func (nop))\n)"
@@ -40,7 +40,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = "(module\n  (func(nop))\n)"
@@ -49,7 +49,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = "(module\n  (func (nop)nop)\n)"
@@ -58,7 +58,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(module) (module)'
@@ -67,7 +67,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = ";; Tokens can be delimited by parentheses\n\n(module\n  (func(nop))\n)"
@@ -76,7 +76,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = "(module\n  (func;;bla\n  )\n)"
@@ -85,7 +85,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '"(hello world) ;; comment"'
@@ -94,7 +94,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '"hello \" world"'
@@ -103,7 +103,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(hello (; cruel ;) world)'
@@ -112,7 +112,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(hello (; this; is; ( totally; ); fine ;) world)'
@@ -121,7 +121,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(hello (; cruel (; very cruel ;) extremely cruel ;) world)'
@@ -130,7 +130,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 input = '(hello (; cruel ;) happy (; terrible ;) world)'
@@ -139,7 +139,7 @@ actual = Wasminna::SExpressionParser.new.parse(input).entries
 if actual == expected
   print "\e[32m.\e[0m"
 else
-  raise actual.inspect
+  raise "expected #{expected}, got #{actual}"
 end
 
 BEGIN {


### PR DESCRIPTION
The tests were cobbled together without much care and have unsurprisingly got into a bit of a mess. This PR tidies them up to make them more consistent and easier to understand & maintain.

The assertions in the preprocessor tests now use WebAssembly source code instead of Ruby S-expression literals, which is an advantage for readability and maintainability at the expense of those tests no longer being isolated from the S-expression parser. I think that’s an acceptable cost because the S-expression parser is not complicated or interesting enough to be worth the significant hassle of keeping other tests fully isolated from it.