### PR TITLE
Desugar abbreviations inside element segments

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -594,7 +594,7 @@ module Wasminna
           end
         end
       reftype =
-        if peek in 'funcref' | 'externref' | 'func'
+        if peek in 'funcref' | 'externref'
           read
         elsif index.nil?
           'func'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -592,15 +592,10 @@ module Wasminna
       end
       read => 'funcref' | 'externref' => reftype
       items =
-        case reftype
-        in 'funcref' | 'externref'
-          repeatedly do
-            read_list(starting_with: 'item') do
-              parse_instructions
-            end
+        repeatedly do
+          read_list(starting_with: 'item') do
+            parse_instructions
           end
-        in 'func'
-          repeatedly { [RefFunc.new(index: parse_index(context.functions))] }
         end
 
       Element.new(index:, offset:, items:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -590,12 +590,7 @@ module Wasminna
       elsif peek in 'declare'
         read => 'declare'
       end
-      reftype =
-        if peek in 'funcref' | 'externref'
-          read
-        else
-          raise
-        end
+      read => 'funcref' | 'externref' => reftype
       items =
         case reftype
         in 'funcref' | 'externref'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -593,8 +593,6 @@ module Wasminna
       reftype =
         if peek in 'funcref' | 'externref'
           read
-        elsif index.nil?
-          'func'
         else
           raise
         end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -612,7 +612,6 @@ module Wasminna
         in 'func'
           repeatedly { [RefFunc.new(index: parse_index(context.functions))] }
         end
-      index ||= 0 unless offset.nil?
 
       Element.new(index:, offset:, items:)
     end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -581,18 +581,16 @@ module Wasminna
       if peek in 'declare'
         read => 'declare'
       end
-      index =
-        if can_read_list?(starting_with: 'table')
+      if can_read_list?(starting_with: 'table')
+        index =
           read_list(starting_with: 'table') do
             parse_index(context.tables)
           end
-        end
-      offset =
-        if !index.nil? || can_read_list?(starting_with: 'offset')
+        offset =
           read_list(starting_with: 'offset') do
             parse_instructions
           end
-        end
+      end
       reftype =
         if peek in 'funcref' | 'externref'
           read

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -578,9 +578,6 @@ module Wasminna
       if peek in ID_REGEXP
         read => ID_REGEXP
       end
-      if peek in 'declare'
-        read => 'declare'
-      end
       if can_read_list?(starting_with: 'table')
         index =
           read_list(starting_with: 'table') do
@@ -590,6 +587,8 @@ module Wasminna
           read_list(starting_with: 'offset') do
             parse_instructions
           end
+      elsif peek in 'declare'
+        read => 'declare'
       end
       reftype =
         if peek in 'funcref' | 'externref'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -605,14 +605,8 @@ module Wasminna
         case reftype
         in 'funcref' | 'externref'
           repeatedly do
-            read_list do
-              case peek
-              in 'item'
-                read => 'item'
-                parse_instructions
-              else
-                [parse_instruction]
-              end
+            read_list(starting_with: 'item') do
+              parse_instructions
             end
           end
         in 'func'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -588,15 +588,9 @@ module Wasminna
           end
         end
       offset =
-        if !index.nil? || can_read_list?
-          read_list do
-            case peek
-            in 'offset'
-              read => 'offset'
-              parse_instructions
-            else
-              [parse_instruction]
-            end
+        if !index.nil? || can_read_list?(starting_with: 'offset')
+          read_list(starting_with: 'offset') do
+            parse_instructions
           end
         end
       reftype =

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -343,18 +343,19 @@ module Wasminna
     end
 
     def process_declarative_element_segment(id:)
-      rest = repeatedly { read }
+      read => 'declare'
+      element_list = process_element_list(func_optional: false)
 
       [
-        ['elem', *id, *rest]
+        ['elem', *id, 'declare', *element_list]
       ]
     end
 
     def process_passive_element_segment(id:)
-      rest = repeatedly { read }
+      element_list = process_element_list(func_optional: false)
 
       [
-        ['elem', *id, *rest]
+        ['elem', *id, *element_list]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -396,12 +396,15 @@ module Wasminna
     end
 
     def process_element_expression
-      if peek in 'item'
-        read => 'item' => kind
-      end
-      instructions = process_instructions
+      instructions =
+        if peek in 'item'
+          read => 'item'
+          process_instructions
+        else
+          process_instruction
+        end
 
-      [*kind, *instructions]
+      ['item', *instructions]
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -336,17 +336,17 @@ module Wasminna
     def process_active_element_segment(id:)
       table_use =
         if can_read_list?(starting_with: 'table')
-          [read]
+          read
         end
       offset = read_list { process_offset }
       element_list = process_element_list(func_optional: table_use.nil?)
 
       if table_use.nil?
-        table_use = [%w[table 0]]
+        table_use = %w[table 0]
       end
 
       [
-        ['elem', *id, *table_use, offset, *element_list]
+        ['elem', *id, table_use, offset, *element_list]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -341,7 +341,7 @@ module Wasminna
       offset = read_list { process_offset }
       element_list = process_element_list(func_optional: table_use.nil?)
 
-      if table_use.nil? && (element_list in ['funcref' | 'externref' | 'func', *])
+      if table_use.nil?
         table_use = [%w[table 0]]
       end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -335,15 +335,10 @@ module Wasminna
           [read]
         end
       offset = read_list { process_offset }
-      if peek in 'funcref' | 'externref'
-        read => 'funcref' | 'externref' => reftype
-      elsif !table_use.nil? || (peek in 'func')
-        read => 'func' => reftype
-      end
-      items = repeatedly { read }
+      element_list = process_element_list(func_optional: table_use.nil?)
 
       [
-        ['elem', *id, *table_use, offset, *reftype, *items]
+        ['elem', *id, *table_use, offset, *element_list]
       ]
     end
 
@@ -370,6 +365,17 @@ module Wasminna
       instructions = process_instructions
 
       [*kind, *instructions]
+    end
+
+    def process_element_list(func_optional:)
+      if peek in 'funcref' | 'externref'
+        read => 'funcref' | 'externref' => reftype
+      elsif !func_optional || (peek in 'func')
+        read => 'func' => reftype
+      end
+      items = repeatedly { read }
+
+      [*reftype, *items]
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -382,10 +382,13 @@ module Wasminna
 
         [reftype, *items]
       elsif !func_optional || (peek in 'func')
-        read => 'func' => reftype
-        items = repeatedly { read }
+        read => 'func'
+        items =
+          read_list(from: process_function_indexes) do
+            process_element_expressions
+          end
 
-        [reftype, *items]
+        ['funcref', *items]
       else
         items = repeatedly { read }
 
@@ -409,6 +412,10 @@ module Wasminna
         end
 
       ['item', *instructions]
+    end
+
+    def process_function_indexes
+      repeatedly { ['ref.func', read] }
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -385,18 +385,16 @@ module Wasminna
         items = process_element_expressions
 
         [reftype, *items]
-      elsif !func_optional || (peek in 'func')
-        read => 'func'
+      else
+        if !func_optional || (peek in 'func')
+          read => 'func'
+        end
         items =
           read_list(from: process_function_indexes) do
             process_element_expressions
           end
 
         ['funcref', *items]
-      else
-        items = repeatedly { read }
-
-        [*items]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -319,6 +319,33 @@ module Wasminna
       if peek in ID_REGEXP
         read => ID_REGEXP => id
       end
+
+      if can_read_list?
+        process_active_element_segment(id:)
+      elsif peek in 'declare'
+        process_declarative_element_segment(id:)
+      else
+        process_passive_element_segment(id:)
+      end
+    end
+
+    def process_active_element_segment(id:)
+      rest = repeatedly { read }
+
+      [
+        ['elem', *id, *rest]
+      ]
+    end
+
+    def process_declarative_element_segment(id:)
+      rest = repeatedly { read }
+
+      [
+        ['elem', *id, *rest]
+      ]
+    end
+
+    def process_passive_element_segment(id:)
       rest = repeatedly { read }
 
       [

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -334,10 +334,11 @@ module Wasminna
         if can_read_list?(starting_with: 'table')
           [read]
         end
+      offset = read_list { process_offset }
       rest = repeatedly { read }
 
       [
-        ['elem', *id, *table_use, *rest]
+        ['elem', *id, *table_use, offset, *rest]
       ]
     end
 
@@ -355,6 +356,10 @@ module Wasminna
       [
         ['elem', *id, *rest]
       ]
+    end
+
+    def process_offset
+      repeatedly { read }
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -379,14 +379,18 @@ module Wasminna
       if peek in 'funcref' | 'externref'
         read => 'funcref' | 'externref' => reftype
         items = process_element_expressions
+
+        [reftype, *items]
       elsif !func_optional || (peek in 'func')
         read => 'func' => reftype
         items = repeatedly { read }
+
+        [reftype, *items]
       else
         items = repeatedly { read }
-      end
 
-      [*reftype, *items]
+        [*items]
+      end
     end
 
     def process_element_expressions

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -335,10 +335,15 @@ module Wasminna
           [read]
         end
       offset = read_list { process_offset }
-      rest = repeatedly { read }
+      if peek in 'funcref' | 'externref'
+        read => 'funcref' | 'externref' => reftype
+      elsif !table_use.nil? || (peek in 'func')
+        read => 'func' => reftype
+      end
+      items = repeatedly { read }
 
       [
-        ['elem', *id, *table_use, offset, *rest]
+        ['elem', *id, *table_use, offset, *reftype, *items]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -359,7 +359,12 @@ module Wasminna
     end
 
     def process_offset
-      repeatedly { read }
+      if peek in 'offset'
+        read => 'offset' => kind
+      end
+      instructions = process_instructions
+
+      [*kind, *instructions]
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -389,7 +389,12 @@ module Wasminna
     end
 
     def process_element_expression
-      repeatedly { read }
+      if peek in 'item'
+        read => 'item' => kind
+      end
+      instructions = process_instructions
+
+      [*kind, *instructions]
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -341,6 +341,10 @@ module Wasminna
       offset = read_list { process_offset }
       element_list = process_element_list(func_optional: table_use.nil?)
 
+      if table_use.nil? && (element_list in ['funcref' | 'externref' | 'func', *])
+        table_use = [%w[table 0]]
+      end
+
       [
         ['elem', *id, *table_use, offset, *element_list]
       ]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -371,7 +371,7 @@ module Wasminna
     def process_element_list(func_optional:)
       if peek in 'funcref' | 'externref'
         read => 'funcref' | 'externref' => reftype
-        items = repeatedly { read }
+        items = process_element_expressions
       elsif !func_optional || (peek in 'func')
         read => 'func' => reftype
         items = repeatedly { read }
@@ -380,6 +380,16 @@ module Wasminna
       end
 
       [*reftype, *items]
+    end
+
+    def process_element_expressions
+      repeatedly do
+        read_list { process_element_expression }
+      end
+    end
+
+    def process_element_expression
+      repeatedly { read }
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -371,10 +371,13 @@ module Wasminna
     def process_element_list(func_optional:)
       if peek in 'funcref' | 'externref'
         read => 'funcref' | 'externref' => reftype
+        items = repeatedly { read }
       elsif !func_optional || (peek in 'func')
         read => 'func' => reftype
+        items = repeatedly { read }
+      else
+        items = repeatedly { read }
       end
-      items = repeatedly { read }
 
       [*reftype, *items]
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -269,6 +269,10 @@ module Wasminna
       end.flatten(1)
     end
 
+    def process_instruction
+      process_instructions # TODO only process one instruction
+    end
+
     def process_type_definition
       read => 'type'
       if peek in ID_REGEXP
@@ -360,12 +364,15 @@ module Wasminna
     end
 
     def process_offset
-      if peek in 'offset'
-        read => 'offset' => kind
-      end
-      instructions = process_instructions
+      instructions =
+        if peek in 'offset'
+          read => 'offset'
+          process_instructions
+        else
+          process_instruction
+        end
 
-      [*kind, *instructions]
+      ['offset', *instructions]
     end
 
     def process_element_list(func_optional:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -330,10 +330,14 @@ module Wasminna
     end
 
     def process_active_element_segment(id:)
+      table_use =
+        if can_read_list?(starting_with: 'table')
+          [read]
+        end
       rest = repeatedly { read }
 
       [
-        ['elem', *id, *rest]
+        ['elem', *id, *table_use, *rest]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -89,6 +89,8 @@ module Wasminna
         process_type_definition
       in 'import'
         process_import
+      in 'elem'
+        process_element_segment
       else
         [repeatedly { read }]
       end
@@ -310,6 +312,18 @@ module Wasminna
       else
         repeatedly { read }
       end
+    end
+
+    def process_element_segment
+      read => 'elem'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
+      rest = repeatedly { read }
+
+      [
+        ['elem', *id, *rest]
+      ]
     end
 
     def process_assert_trap

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -372,6 +372,16 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (offset i32.const 0) funcref (item ref.func $f))
+  )
+--
+  (module
+    (elem (table 0) (offset i32.const 0) funcref (item ref.func $f))
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -330,6 +330,48 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem
+      func $f $g
+    )
+  )
+--
+  (module
+    (elem
+      funcref (item ref.func $f) (item ref.func $g)
+    )
+  )
+--
+
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (table 0) (offset i32.const 0)
+      func $f $g
+    )
+  )
+--
+  (module
+    (elem (table 0) (offset i32.const 0)
+      funcref (item ref.func $f) (item ref.func $g)
+    )
+  )
+--
+
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem declare
+      func $f $g
+    )
+  )
+--
+  (module
+    (elem declare
+      funcref (item ref.func $f) (item ref.func $g)
+    )
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -290,6 +290,16 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (table $t) (i32.const 0) funcref (item ref.func $f))
+  )
+--
+  (module
+    (elem (table $t) (offset i32.const 0) funcref (item ref.func $f))
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -256,6 +256,26 @@ assert_preprocess <<'--', <<'--'
   (module $M2 binary "\00asm" "\01\00\00\00")
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (table $t)
+      (offset
+        (call_indirect (param i32 i64) (result f32 f64))
+      )
+      funcref (item ref.func $f)
+    )
+  )
+--
+  (module
+    (elem (table $t)
+      (offset
+        (call_indirect (param i32) (param i64) (result f32) (result f64))
+      )
+      funcref (item ref.func $f)
+    )
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -382,6 +382,20 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (offset i32.const 0)
+      $f $g
+    )
+  )
+--
+  (module
+    (elem (table 0) (offset i32.const 0)
+      funcref (item ref.func $f) (item ref.func $g)
+    )
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -300,6 +300,36 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem funcref (ref.func $f))
+  )
+--
+  (module
+    (elem funcref (item ref.func $f))
+  )
+--
+
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (table 0) (offset i32.const 0) funcref (ref.func $f))
+  )
+--
+  (module
+    (elem (table 0) (offset i32.const 0) funcref (item ref.func $f))
+  )
+--
+
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem declare funcref (ref.func $f))
+  )
+--
+  (module
+    (elem declare funcref (item ref.func $f))
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -276,6 +276,20 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (elem (table $t) (offset i32.const 0) funcref
+      (item (call_indirect (param i32 i64) (result f32 f64)))
+    )
+  )
+--
+  (module
+    (elem (table $t) (offset i32.const 0) funcref
+      (item (call_indirect (param i32) (param i64) (result f32) (result f64)))
+    )
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
Element segments support [several abbreviations](https://webassembly.github.io/spec/core/text/modules.html#id7):

* a single instruction may appear in place of the offset of an active element segment (i.e. the `offset` keyword may be omitted);
* a single instruction may appear as an element expression (i.e. the `item` keyword may be omitted);
* the element list may be written as a sequence of function indexes;
* the table use may be omitted; and
* if the table use is omitted, the `func` keyword may be omitted as well.

This PR implements desugaring for these abbreviations in the preprocessor and removes support for them from the AST parser. We have to be careful to implement them in an order which allows all of the existing tests to continue passing without modification.