### PR TITLE
Desugar inline element segment abbreviation inside table definitions

### DIFF
--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -26,7 +26,7 @@ module Wasminna
     GlobalGet = Data.define(:index)
     Function = Data.define(:type_index, :locals, :body)
     Memory = Data.define(:string, :minimum_size, :maximum_size)
-    Table = Data.define(:name, :minimum_size, :maximum_size, :elements)
+    Table = Data.define(:name, :minimum_size, :maximum_size)
     Global = Data.define(:value)
     Module = Data.define(:name, :functions, :memory, :tables, :globals, :types, :datas, :exports, :imports, :elements, :start)
     Invoke = Data.define(:module_name, :name, :arguments)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -462,7 +462,7 @@ module Wasminna
       end
       minimum_size, maximum_size, reftype = parse_tabletype
 
-      Table.new(name:, minimum_size:, maximum_size:, elements: nil)
+      Table.new(name:, minimum_size:, maximum_size:)
     end
 
     def parse_tabletype

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -480,26 +480,6 @@ module Wasminna
       [minimum_size, maximum_size]
     end
 
-    def parse_table_element
-      read_list(starting_with: 'elem') do
-        if can_read_list?
-          repeatedly do
-            read_list do
-              case peek
-              in 'item'
-                read => 'item'
-                parse_instructions
-              else
-                [parse_instruction]
-              end
-            end
-          end
-        else
-          repeatedly { [RefFunc.new(index: parse_index(context.functions))] }
-        end
-      end
-    end
-
     def parse_global
       read => 'global'
       if peek in ID_REGEXP

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -460,15 +460,9 @@ module Wasminna
       if peek in ID_REGEXP
         read => ID_REGEXP => name
       end
+      minimum_size, maximum_size, reftype = parse_tabletype
 
-      if peek in UNSIGNED_INTEGER_REGEXP
-        minimum_size, maximum_size, reftype = parse_tabletype
-      else
-        read => 'funcref' | 'externref' => reftype
-        elements = parse_table_element
-      end
-
-      Table.new(name:, minimum_size:, maximum_size:, elements:)
+      Table.new(name:, minimum_size:, maximum_size:, elements: nil)
     end
 
     def parse_tabletype

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -205,7 +205,7 @@ module Wasminna
       initialise_functions
       initialise_globals(imports: mod.imports, globals: mod.globals)
       initialise_memory(datas: mod.datas)
-      initialise_tables(tables: mod.tables, elements: mod.elements)
+      initialise_tables(elements: mod.elements)
 
       if mod.start
         invoke_function(functions.slice(mod.start))
@@ -311,18 +311,7 @@ module Wasminna
       end
     end
 
-    def initialise_tables(tables:, elements:)
-      tables.each.with_index do |table, table_index|
-        next if table.elements.nil?
-
-        table_instance = current_module.tables.slice(table_index)
-        table.elements.each.with_index do |element, element_index|
-          evaluate_expression(element, locals: [])
-          stack.pop(1) => [value]
-          table_instance.elements[element_index] = value
-        end
-      end
-
+    def initialise_tables(elements:)
       elements.reject { _1.offset.nil? }.each do |element|
         table_instance = current_module.tables.slice(element.index)
         evaluate_expression(element.offset, locals: [])

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -233,7 +233,7 @@ module Wasminna
 
       table_imports +
         tables.map do |table|
-          Table.new(elements: Array.new(table.minimum_size || table.elements.length), maximum_size: table.maximum_size)
+          Table.new(elements: Array.new(table.minimum_size), maximum_size: table.maximum_size)
         end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -140,9 +140,16 @@ module Wasminna
 
     def expand_inline_element_segment(id:)
       read => 'funcref' | 'externref' => reftype
-      items =
+      item_type, items =
         read_list(starting_with: 'elem') do
-          repeatedly { read }
+          item_type =
+            if can_read_list?
+              reftype
+            else
+              'func'
+            end
+          items = repeatedly { read }
+          [item_type, items]
         end
 
       [

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -152,9 +152,18 @@ module Wasminna
           [item_type, items]
         end
 
-      [
-        ['table', *id, reftype, ['elem', *items]]
-      ]
+      if id.nil?
+        id = "$__fresh_#{fresh_id}" # TODO find a better way
+        self.fresh_id += 1
+      end
+      limit = items.length.to_s
+      expanded =
+        [
+          ['table', id, limit, limit, reftype],
+          ['elem', ['table', id], %w[i32.const 0], item_type, *items]
+        ]
+
+      read_list(from: expanded) { process_fields }
     end
 
     def process_memory_definition

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -396,6 +396,28 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (table $t funcref (elem (item ref.func $f) (item ref.func $g)))
+  )
+--
+  (module
+    (table $t 2 2 funcref)
+    (elem (table $t) (offset i32.const 0) funcref (item ref.func $f) (item ref.func $g))
+  )
+--
+
+assert_preprocess <<'--', <<'--'
+  (module
+    (table $t funcref (elem $f $g))
+  )
+--
+  (module
+    (table $t 2 2 funcref)
+    (elem (table $t) (offset i32.const 0) funcref (item ref.func $f) (item ref.func $g))
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
A table definition can include an [inline element segment](https://webassembly.github.io/spec/core/text/modules.html#text-table-abbrev). This PR implements desugaring for that abbreviation in the preprocessor and removes support for it from the AST parser, AST nodes and interpreter.

This work required [reporting](https://github.com/WebAssembly/spec/issues/1656) and [fixing](https://github.com/WebAssembly/spec/pull/1657) an issue in the WebAssembly language specification to correct the expanded syntax of element lists.