### PR TITLE
Desugar abbreviations inside data segments

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -422,11 +422,9 @@ module Wasminna
         read => ID_REGEXP
       end
 
-      if can_read_list?
-        if can_read_list?(starting_with: 'memory')
-          read_list(starting_with: 'memory') do
-            parse_index(context.mems)
-          end
+      if can_read_list?(starting_with: 'memory')
+        read_list(starting_with: 'memory') do
+          parse_index(context.mems)
         end
         offset =
           read_list(starting_with: 'offset') do

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -429,14 +429,8 @@ module Wasminna
           end
         end
         offset =
-          read_list do
-            case peek
-            in 'offset'
-              read => 'offset'
-              parse_instructions
-            else
-              [parse_instruction]
-            end
+          read_list(starting_with: 'offset') do
+            parse_instructions
           end
       end
       string = repeatedly { parse_string }.join

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -473,6 +473,8 @@ module Wasminna
       memory_use =
         if can_read_list?(starting_with: 'memory')
           [read]
+        else
+          [%w[memory 0]]
         end
       offset = read_list { process_offset }
       strings = repeatedly { read }

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -461,6 +461,23 @@ module Wasminna
       if peek in ID_REGEXP
         read => ID_REGEXP => id
       end
+
+      if can_read_list?
+        process_active_data_segment(id:)
+      else
+        process_passive_data_segment(id:)
+      end
+    end
+
+    def process_active_data_segment(id:)
+      rest = repeatedly { read }
+
+      [
+        ['data', *id, *rest]
+      ]
+    end
+
+    def process_passive_data_segment(id:)
       rest = repeatedly { read }
 
       [

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -474,10 +474,11 @@ module Wasminna
         if can_read_list?(starting_with: 'memory')
           [read]
         end
-      rest = repeatedly { read }
+      offset = read_list { process_offset }
+      strings = repeatedly { read }
 
       [
-        ['data', *id, *memory_use, *rest]
+        ['data', *id, *memory_use, offset, *strings]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -470,10 +470,14 @@ module Wasminna
     end
 
     def process_active_data_segment(id:)
+      memory_use =
+        if can_read_list?(starting_with: 'memory')
+          [read]
+        end
       rest = repeatedly { read }
 
       [
-        ['data', *id, *rest]
+        ['data', *id, *memory_use, *rest]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -91,6 +91,8 @@ module Wasminna
         process_import
       in 'elem'
         process_element_segment
+      in 'data'
+        process_data_segment
       else
         [repeatedly { read }]
       end
@@ -452,6 +454,18 @@ module Wasminna
 
     def process_function_indexes
       repeatedly { ['ref.func', read] }
+    end
+
+    def process_data_segment
+      read => 'data'
+      if peek in ID_REGEXP
+        read => ID_REGEXP => id
+      end
+      rest = repeatedly { read }
+
+      [
+        ['data', *id, *rest]
+      ]
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -472,15 +472,15 @@ module Wasminna
     def process_active_data_segment(id:)
       memory_use =
         if can_read_list?(starting_with: 'memory')
-          [read]
+          read
         else
-          [%w[memory 0]]
+          %w[memory 0]
         end
       offset = read_list { process_offset }
       strings = repeatedly { read }
 
       [
-        ['data', *id, *memory_use, offset, *strings]
+        ['data', *id, memory_use, offset, *strings]
       ]
     end
 

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -448,6 +448,16 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (data $d (offset i32.const 0) "hello" "world")
+  )
+--
+  (module
+    (data $d (memory 0) (offset i32.const 0) "hello" "world")
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -418,6 +418,36 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (data (memory $m)
+      (offset
+        (call_indirect (param i32 i64) (result f32 f64))
+      )
+      "hello" "world"
+    )
+  )
+--
+  (module
+    (data (memory $m)
+      (offset
+        (call_indirect (param i32) (param i64) (result f32) (result f64))
+      )
+      "hello" "world"
+    )
+  )
+--
+
+assert_preprocess <<'--', <<'--'
+  (module
+    (data $d (memory $m) (i32.const 0) "hello" "world")
+  )
+--
+  (module
+    (data $d (memory $m) (offset i32.const 0) "hello" "world")
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
Data segments support [two abbreviations](https://webassembly.github.io/spec/core/text/modules.html#id8):

* a single instruction may appear in place of the offset of an active data segment (i.e. the `offset` keyword may be omitted); and
* the memory use may be omitted.

This PR implements desugaring for these abbreviations in the preprocessor and removes support for them from the AST parser.