### PR TITLE
Desugar inline data segment abbreviation inside memory definitions

### DIFF
--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -25,7 +25,7 @@ module Wasminna
     MemoryGrow = Data.define
     GlobalGet = Data.define(:index)
     Function = Data.define(:type_index, :locals, :body)
-    Memory = Data.define(:string, :minimum_size, :maximum_size)
+    Memory = Data.define(:minimum_size, :maximum_size)
     Table = Data.define(:name, :minimum_size, :maximum_size)
     Global = Data.define(:value)
     Module = Data.define(:name, :functions, :memory, :tables, :globals, :types, :datas, :exports, :imports, :elements, :start)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -8,6 +8,7 @@ module Wasminna
     include AST
     include Helpers::Mask
     include Helpers::ReadFromSExpression
+    include Helpers::StringValue
 
     def parse_script(s_expression)
       read_list(from: s_expression) do
@@ -1010,15 +1011,7 @@ module Wasminna
     end
 
     def parse_string
-      read => string
-      encoding = string.encoding
-      string.
-        delete_prefix('"').delete_suffix('"').
-        force_encoding(Encoding::ASCII_8BIT).
-        gsub(%r{\\\h{2}}) do |digits|
-          digits.delete_prefix('\\').to_i(16).chr(Encoding::ASCII_8BIT)
-        end.
-        force_encoding(encoding)
+      string_value(read)
     end
 
     def unzip_pairs(pairs)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -409,7 +409,7 @@ module Wasminna
         parse_limits => [minimum_size, maximum_size]
       end
 
-      Memory.new(string:, minimum_size:, maximum_size:)
+      AST::Memory.new(string:, minimum_size:, maximum_size:)
     end
 
     def parse_memory_data

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -404,7 +404,7 @@ module Wasminna
       end
       parse_limits => [minimum_size, maximum_size]
 
-      AST::Memory.new(string: nil, minimum_size:, maximum_size:)
+      AST::Memory.new(minimum_size:, maximum_size:)
     end
 
     def parse_data

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -407,11 +407,6 @@ module Wasminna
       AST::Memory.new(string: nil, minimum_size:, maximum_size:)
     end
 
-    def parse_memory_data
-      read => 'data'
-      repeatedly { parse_string }.join
-    end
-
     def parse_data
       read => 'data'
       if peek in ID_REGEXP

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -402,14 +402,9 @@ module Wasminna
       if peek in ID_REGEXP
         read => ID_REGEXP
       end
+      parse_limits => [minimum_size, maximum_size]
 
-      if can_read_list?(starting_with: 'data')
-        string = read_list { parse_memory_data }
-      else
-        parse_limits => [minimum_size, maximum_size]
-      end
-
-      AST::Memory.new(string:, minimum_size:, maximum_size:)
+      AST::Memory.new(string: nil, minimum_size:, maximum_size:)
     end
 
     def parse_memory_data

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -62,5 +62,20 @@ module Wasminna
         s_expression.shift
       end
     end
+
+    module StringValue
+      private
+
+      def string_value(string)
+        encoding = string.encoding
+        string.
+          delete_prefix('"').delete_suffix('"').
+          force_encoding(Encoding::ASCII_8BIT).
+          gsub(%r{\\\h{2}}) do |digits|
+            digits.delete_prefix('\\').to_i(16).chr(Encoding::ASCII_8BIT)
+          end.
+          force_encoding(encoding)
+      end
+    end
   end
 end

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -196,13 +196,9 @@ module Wasminna
         imported_memory
       in [], _
         unless memory.nil?
-          if memory.string.nil?
-            Memory.from_limits \
-              minimum_size: memory.minimum_size,
-              maximum_size: memory.maximum_size
-          else
-            Memory.from_string(string: memory.string)
-          end
+          Memory.from_limits \
+            minimum_size: memory.minimum_size,
+            maximum_size: memory.maximum_size
         end
       end
     end

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -3,67 +3,13 @@ require 'wasminna/float'
 require 'wasminna/float/format'
 require 'wasminna/float/nan'
 require 'wasminna/helpers'
+require 'wasminna/memory'
 require 'wasminna/sign'
 
 module Wasminna
   class Interpreter
     include AST
     include Helpers::Mask
-
-    class Memory < Data.define(:bytes, :maximum_size)
-      include Helpers::Mask
-      include Helpers::SizeOf
-      extend Helpers::SizeOf
-
-      BITS_PER_BYTE = 8
-      BYTES_PER_PAGE = 0x10000
-      MAXIMUM_PAGES = 0x10000
-
-      def self.from_string(string:)
-        size_in_pages = size_of(string.bytesize, in: BYTES_PER_PAGE)
-        bytes = "\0" * (size_in_pages * BYTES_PER_PAGE)
-        bytes[0, string.length] = string
-        new(bytes:, maximum_size: nil)
-      end
-
-      def self.from_limits(minimum_size:, maximum_size:)
-        bytes = "\0" * (minimum_size * BYTES_PER_PAGE)
-        maximum_size =
-          if maximum_size.nil?
-            MAXIMUM_PAGES
-          else
-            maximum_size.clamp(..MAXIMUM_PAGES)
-          end
-        new(bytes:, maximum_size:)
-      end
-
-      def load(offset:, bits:)
-        size_of(bits, in: BITS_PER_BYTE).times
-          .map { |index| bytes.getbyte(offset + index) }
-          .map.with_index { |byte, index| byte << index * BITS_PER_BYTE }
-          .inject(0, &:|)
-      end
-
-      def store(value:, offset:, bits:)
-        size_of(bits, in: BITS_PER_BYTE).times do |index|
-          byte = mask(value >> index * BITS_PER_BYTE, bits: BITS_PER_BYTE)
-          bytes.setbyte(offset + index, byte)
-        end
-      end
-
-      def grow_by(pages:)
-        if maximum_size.nil? || size_in_pages + pages <= maximum_size
-          bytes << "\0" * (pages * BYTES_PER_PAGE)
-          true
-        else
-          false
-        end
-      end
-
-      def size_in_pages
-        size_of(bytes.bytesize, in: BYTES_PER_PAGE)
-      end
-    end
 
     attr_accessor :current_module, :modules, :exports, :stack, :tags
 

--- a/lib/wasminna/memory.rb
+++ b/lib/wasminna/memory.rb
@@ -1,0 +1,56 @@
+module Wasminna
+  class Memory < Data.define(:bytes, :maximum_size)
+    include Helpers::Mask
+    include Helpers::SizeOf
+    extend Helpers::SizeOf
+
+    BITS_PER_BYTE = 8
+    BYTES_PER_PAGE = 0x10000
+    MAXIMUM_PAGES = 0x10000
+
+    def self.from_string(string:)
+      size_in_pages = size_of(string.bytesize, in: BYTES_PER_PAGE)
+      bytes = "\0" * (size_in_pages * BYTES_PER_PAGE)
+      bytes[0, string.length] = string
+      new(bytes:, maximum_size: nil)
+    end
+
+    def self.from_limits(minimum_size:, maximum_size:)
+      bytes = "\0" * (minimum_size * BYTES_PER_PAGE)
+      maximum_size =
+        if maximum_size.nil?
+          MAXIMUM_PAGES
+        else
+          maximum_size.clamp(..MAXIMUM_PAGES)
+        end
+      new(bytes:, maximum_size:)
+    end
+
+    def load(offset:, bits:)
+      size_of(bits, in: BITS_PER_BYTE).times
+        .map { |index| bytes.getbyte(offset + index) }
+        .map.with_index { |byte, index| byte << index * BITS_PER_BYTE }
+        .inject(0, &:|)
+    end
+
+    def store(value:, offset:, bits:)
+      size_of(bits, in: BITS_PER_BYTE).times do |index|
+        byte = mask(value >> index * BITS_PER_BYTE, bits: BITS_PER_BYTE)
+        bytes.setbyte(offset + index, byte)
+      end
+    end
+
+    def grow_by(pages:)
+      if maximum_size.nil? || size_in_pages + pages <= maximum_size
+        bytes << "\0" * (pages * BYTES_PER_PAGE)
+        true
+      else
+        false
+      end
+    end
+
+    def size_in_pages
+      size_of(bytes.bytesize, in: BYTES_PER_PAGE)
+    end
+  end
+end

--- a/lib/wasminna/memory.rb
+++ b/lib/wasminna/memory.rb
@@ -8,13 +8,6 @@ module Wasminna
     BYTES_PER_PAGE = 0x10000
     MAXIMUM_PAGES = 0x10000
 
-    def self.from_string(string:)
-      size_in_pages = size_of(string.bytesize, in: BYTES_PER_PAGE)
-      bytes = "\0" * (size_in_pages * BYTES_PER_PAGE)
-      bytes[0, string.length] = string
-      new(bytes:, maximum_size: nil)
-    end
-
     def self.from_limits(minimum_size:, maximum_size:)
       bytes = "\0" * (minimum_size * BYTES_PER_PAGE)
       maximum_size =

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -458,6 +458,17 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
+assert_preprocess <<'--', <<'--'
+  (module
+    (memory (data "hello" "world"))
+  )
+--
+  (module
+    (memory $__fresh_0 1 1)
+    (data (memory $__fresh_0) (offset i32.const 0) "hello" "world")
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
A memory definition can include an [inline data segment](https://webassembly.github.io/spec/core/text/modules.html#text-mem-abbrev). This PR implements desugaring for that abbreviation in the preprocessor and removes support for it from the AST parser, AST nodes and interpreter.