### PR TITLE
Introduce AST nodes for element & data segment modes

### DIFF
--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -46,7 +46,12 @@ module Wasminna
     Register = Data.define(:module_name, :name)
     TableGet = Data.define(:index)
     TableSet = Data.define(:index)
-    ElementSegment = Data.define(:index, :offset, :items)
+    ElementSegment = Data.define(:index, :offset, :items, :mode)
+    module ElementSegment::Mode
+      Passive = Data.define
+      Active = Data.define(:index, :offset)
+      Declarative = Data.define
+    end
     MemoryFill = Data.define
     MemoryCopy = Data.define
     MemoryInit = Data.define(:index)

--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -46,7 +46,7 @@ module Wasminna
     Register = Data.define(:module_name, :name)
     TableGet = Data.define(:index)
     TableSet = Data.define(:index)
-    Element = Data.define(:index, :offset, :items)
+    ElementSegment = Data.define(:index, :offset, :items)
     MemoryFill = Data.define
     MemoryCopy = Data.define
     MemoryInit = Data.define(:index)

--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -46,7 +46,7 @@ module Wasminna
     Register = Data.define(:module_name, :name)
     TableGet = Data.define(:index)
     TableSet = Data.define(:index)
-    ElementSegment = Data.define(:index, :offset, :items, :mode)
+    ElementSegment = Data.define(:items, :mode)
     module ElementSegment::Mode
       Passive = Data.define
       Active = Data.define(:index, :offset)

--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -35,7 +35,7 @@ module Wasminna
     SkippedAssertion = Data.define
     Type = Data.define(:parameters, :results)
     MemorySize = Data.define
-    MemoryData = Data.define(:offset, :string)
+    DataSegment = Data.define(:offset, :string)
     RefNull = Data.define
     RefExtern = Data.define(:value)
     Get = Data.define(:module_name, :name)

--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -35,7 +35,7 @@ module Wasminna
     SkippedAssertion = Data.define
     Type = Data.define(:parameters, :results)
     MemorySize = Data.define
-    DataSegment = Data.define(:offset, :string, :mode)
+    DataSegment = Data.define(:string, :mode)
     module DataSegment::Mode
       Passive = Data.define
       Active = Data.define(:index, :offset)

--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -35,7 +35,11 @@ module Wasminna
     SkippedAssertion = Data.define
     Type = Data.define(:parameters, :results)
     MemorySize = Data.define
-    DataSegment = Data.define(:offset, :string)
+    DataSegment = Data.define(:offset, :string, :mode)
+    module DataSegment::Mode
+      Passive = Data.define
+      Active = Data.define(:index, :offset)
+    end
     RefNull = Data.define
     RefExtern = Data.define(:value)
     Get = Data.define(:module_name, :name)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -429,7 +429,7 @@ module Wasminna
         end
       string = repeatedly { parse_string }.join
 
-      DataSegment.new(offset:, string:, mode:)
+      DataSegment.new(string:, mode:)
     end
 
     UNSIGNED_INTEGER_REGEXP =

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -560,7 +560,7 @@ module Wasminna
           end
         end
 
-      ElementSegment.new(index:, offset:, items:, mode:)
+      ElementSegment.new(items:, mode:)
     end
 
     def parse_start

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -555,7 +555,7 @@ module Wasminna
           end
         end
 
-      Element.new(index:, offset:, items:)
+      ElementSegment.new(index:, offset:, items:)
     end
 
     def parse_start

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -424,7 +424,7 @@ module Wasminna
       end
       string = repeatedly { parse_string }.join
 
-      MemoryData.new(offset:, string:)
+      DataSegment.new(offset:, string:)
     end
 
     UNSIGNED_INTEGER_REGEXP =

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -413,18 +413,23 @@ module Wasminna
         read => ID_REGEXP
       end
 
-      if can_read_list?(starting_with: 'memory')
-        read_list(starting_with: 'memory') do
-          parse_index(context.mems)
+      mode =
+        if can_read_list?(starting_with: 'memory')
+          index =
+            read_list(starting_with: 'memory') do
+              parse_index(context.mems)
+            end
+          offset =
+            read_list(starting_with: 'offset') do
+              parse_instructions
+            end
+          DataSegment::Mode::Active.new(index:, offset:)
+        else
+          DataSegment::Mode::Passive.new
         end
-        offset =
-          read_list(starting_with: 'offset') do
-            parse_instructions
-          end
-      end
       string = repeatedly { parse_string }.join
 
-      DataSegment.new(offset:, string:)
+      DataSegment.new(offset:, string:, mode:)
     end
 
     UNSIGNED_INTEGER_REGEXP =

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -254,9 +254,9 @@ module Wasminna
     end
 
     def initialise_tables(elements:)
-      elements.reject { _1.offset.nil? }.each do |element|
-        table_instance = current_module.tables.slice(element.index)
-        evaluate_expression(element.offset, locals: [])
+      elements.select { _1.mode.is_a?(ElementSegment::Mode::Active) }.each do |element|
+        table_instance = current_module.tables.slice(element.mode.index)
+        evaluate_expression(element.mode.offset, locals: [])
         stack.pop(1) => [offset]
         raise if offset + element.items.length > table_instance.elements.length
 

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -254,16 +254,18 @@ module Wasminna
     end
 
     def initialise_tables(elements:)
-      elements.select { _1.mode.is_a?(ElementSegment::Mode::Active) }.each do |element|
-        table_instance = current_module.tables.slice(element.mode.index)
-        evaluate_expression(element.mode.offset, locals: [])
-        stack.pop(1) => [offset]
-        raise if offset + element.items.length > table_instance.elements.length
+      elements.each do |element|
+        if element in items:, mode: ElementSegment::Mode::Active(index:, offset:)
+          table_instance = current_module.tables.slice(index)
+          evaluate_expression(offset, locals: [])
+          stack.pop(1) => [offset]
+          raise if offset + items.length > table_instance.elements.length
 
-        element.items.each.with_index do |item, item_index|
-          evaluate_expression(item, locals: [])
-          stack.pop(1) => [value]
-          table_instance.elements[offset + item_index] = value
+          items.each.with_index do |item, item_index|
+            evaluate_expression(item, locals: [])
+            stack.pop(1) => [value]
+            table_instance.elements[offset + item_index] = value
+          end
         end
       end
     end

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -243,8 +243,8 @@ module Wasminna
     end
 
     def initialise_memory(datas:)
-      datas.reject { _1.offset.nil? }.each do |data|
-        evaluate_expression(data.offset, locals: [])
+      datas.select { _1.mode.is_a?(DataSegment::Mode::Active) }.each do |data|
+        evaluate_expression(data.mode.offset, locals: [])
         stack.pop(1) => [offset]
         raise if offset + data.string.bytesize > current_module.memory.bytes.bytesize
         data.string.each_byte.with_index do |value, index|

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -461,9 +461,11 @@ module Wasminna
       in MemoryInit(index:)
         stack.pop(3) => [destination, source, length]
         unless length.zero?
-          data = current_module.datas.slice(index)
-          data.string.byteslice(source, length).each_byte.with_index do |value, index|
-            current_module.memory.store(value:, offset: destination + index, bits: Memory::BITS_PER_BYTE)
+          case current_module.datas.slice(index)
+          in DataSegment(string:, mode: DataSegment::Mode::Passive)
+            string.byteslice(source, length).each_byte.with_index do |value, index|
+              current_module.memory.store(value:, offset: destination + index, bits: Memory::BITS_PER_BYTE)
+            end
           end
         end
       in DataDrop(index:)

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -244,7 +244,8 @@ module Wasminna
 
     def initialise_memory(datas:)
       datas.each do |data|
-        if data in string:, mode: DataSegment::Mode::Active(index:, offset:)
+        if data in string:, mode: DataSegment::Mode::Active(offset:) => mode
+          mode => { index: 0 }
           evaluate_expression(offset, locals: [])
           stack.pop(1) => [offset]
           raise if offset + string.bytesize > current_module.memory.bytes.bytesize

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -243,12 +243,14 @@ module Wasminna
     end
 
     def initialise_memory(datas:)
-      datas.select { _1.mode.is_a?(DataSegment::Mode::Active) }.each do |data|
-        evaluate_expression(data.mode.offset, locals: [])
-        stack.pop(1) => [offset]
-        raise if offset + data.string.bytesize > current_module.memory.bytes.bytesize
-        data.string.each_byte.with_index do |value, index|
-          current_module.memory.store(value:, offset: offset + index, bits: Memory::BITS_PER_BYTE)
+      datas.each do |data|
+        if data in string:, mode: DataSegment::Mode::Active(index:, offset:)
+          evaluate_expression(offset, locals: [])
+          stack.pop(1) => [offset]
+          raise if offset + string.bytesize > current_module.memory.bytes.bytesize
+          string.each_byte.with_index do |value, index|
+            current_module.memory.store(value:, offset: offset + index, bits: Memory::BITS_PER_BYTE)
+          end
         end
       end
     end

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -468,12 +468,16 @@ module Wasminna
         current_module.datas[index] = nil
       in TableInit(table_index:, element_index:)
         stack.pop(3) => [destination, source, length]
-        table = current_module.tables.slice(table_index)
-        element = current_module.elements.slice(element_index)
-        length.times do |index|
-          evaluate_expression(element.items.slice(source + index), locals: [])
-          stack.pop(1) => [value]
-          table.elements[destination + index] = value
+        unless length.zero?
+          table = current_module.tables.slice(table_index)
+          case current_module.elements.slice(element_index)
+          in ElementSegment(items:, mode: ElementSegment::Mode::Passive)
+            length.times do |index|
+              evaluate_expression(items.slice(source + index), locals: [])
+              stack.pop(1) => [value]
+              table.elements[destination + index] = value
+            end
+          end
         end
       in ElemDrop(index:)
         current_module.elements[index] = nil


### PR DESCRIPTION
Every [element segment](https://webassembly.github.io/spec/core/syntax/modules.html#element-segments) and [data segment](https://webassembly.github.io/spec/core/syntax/modules.html#data-segments) has a mode which indicates when its contents may be used (i.e. during module instantiation, during execution, or not at all). This PR introduces AST nodes to represent these modes explicitly and store any mode-specific data, which makes it more obvious which segment mode is being used at each time.