### PR TITLE
Tidy up preprocessor and parser

### DIFF
--- a/lib/wasminna/ast.rb
+++ b/lib/wasminna/ast.rb
@@ -28,7 +28,7 @@ module Wasminna
     Memory = Data.define(:minimum_size, :maximum_size)
     Table = Data.define(:name, :minimum_size, :maximum_size)
     Global = Data.define(:value)
-    Module = Data.define(:name, :functions, :memory, :tables, :globals, :types, :datas, :exports, :imports, :elements, :start)
+    Module = Data.define(:name, :functions, :memories, :tables, :globals, :types, :datas, :exports, :imports, :elements, :start)
     Invoke = Data.define(:module_name, :name, :arguments)
     AssertReturn = Data.define(:action, :expecteds)
     NanExpectation = Data.define(:nan, :bits)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -63,7 +63,7 @@ module Wasminna
       # TODO
       repeatedly { read }
 
-      { functions: [], memory: nil, tables: [], globals: [], types: [], datas: [], exports: [], imports: [], elements: [], start: nil }
+      { functions: [], memories: [], tables: [], globals: [], types: [], datas: [], exports: [], imports: [], elements: [], start: nil }
     end
 
     Context = Data.define(:types, :functions, :tables, :mems, :globals, :elem, :data, :locals, :labels, :typedefs) do
@@ -88,8 +88,8 @@ module Wasminna
     end
 
     def parse_text_fields
-      functions, memory, tables, globals, datas, exports, imports, elements, start =
-        [], nil, [], [], [], [], [], [], nil
+      functions, memories, tables, globals, datas, exports, imports, elements, start =
+        [], [], [], [], [], [], [], [], nil
       initial_context =
         read_list(from: Marshal.load(Marshal.dump(s_expression))) do
           build_initial_context
@@ -102,7 +102,7 @@ module Wasminna
             in 'func'
               functions << parse_function_definition
             in 'memory'
-              memory = parse_memory_definition
+              memories << parse_memory_definition
             in 'table'
               tables << parse_table_definition
             in 'global'
@@ -123,7 +123,7 @@ module Wasminna
           end
         end
 
-        { functions:, memory:, tables:, globals:, datas:, exports:, imports:, elements:, start:, types: context.typedefs }
+        { functions:, memories:, tables:, globals:, datas:, exports:, imports:, elements:, start:, types: context.typedefs }
       end
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -876,24 +876,12 @@ module Wasminna
         read_index => index
         if can_read_index?
           table_index =
-            if index.start_with?('$')
-              context.tables.index(index) || raise
-            elsif index.start_with?('0x')
-              index.to_i(16)
-            else
-              index.to_i(10)
-            end
+            read_list(from: [index]) { parse_index(context.tables) }
           element_index = parse_index(context.elem)
         else
           table_index = 0
           element_index =
-            if index.start_with?('$')
-              context.elem.index(index) || raise
-            elsif index.start_with?('0x')
-              index.to_i(16)
-            else
-              index.to_i(10)
-            end
+            read_list(from: [index]) { parse_index(context.elem) }
         end
 
         TableInit.new(table_index:, element_index:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -856,7 +856,8 @@ module Wasminna
           else
             0
           end
-        parse_typeuse => [type_index, _]
+        parse_typeuse => [type_index, parameter_names]
+        raise unless parameter_names.all?(&:nil?)
 
         CallIndirect.new(table_index:, type_index:)
       in 'select'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -198,12 +198,13 @@ module Wasminna
     def parse_assert_return
       read => 'assert_return'
       action =
-        if can_read_list?(starting_with: 'invoke')
-          read_list { parse_invoke }
-        elsif can_read_list?(starting_with: 'get')
-          read_list { parse_get }
-        else
-          raise
+        read_list do
+          case peek
+          in 'invoke'
+            parse_invoke
+          in 'get'
+            parse_get
+          end
         end
       expecteds = parse_expecteds
 
@@ -213,14 +214,15 @@ module Wasminna
     def parse_assert_trap
       read => 'assert_trap'
       action =
-        if can_read_list?(starting_with: 'invoke')
-          read_list { parse_invoke }
-        elsif can_read_list?(starting_with: 'get')
-          read_list { parse_get }
-        elsif can_read_list?(starting_with: 'module')
-          read_list { parse_module }
-        else
-          raise
+        read_list do
+          case peek
+          in 'invoke'
+            parse_invoke
+          in 'get'
+            parse_get
+          in 'module'
+            parse_module
+          end
         end
       failure = parse_string
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -398,10 +398,10 @@ module Wasminna
     UNSIGNED_INTEGER_REGEXP =
       %r{
         \A
-        (
-          \d (_? \d)*
+        (?:
+          \d (?: _? \d)*
           |
-          0x \h (_? \h)*
+          0x \h (?: _? \h)*
         )
         \z
       }x

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -135,7 +135,7 @@ module Wasminna
             read_optional_id => name
             type =
               read_list(starting_with: 'func') do
-                _, parameters = unzip_pairs(parse_parameters)
+                _, parameters = parse_parameters
                 results = parse_results
                 Type.new(parameters:, results:)
               end
@@ -275,7 +275,7 @@ module Wasminna
 
       read_list do
         read => 'func'
-        _, parameters = unzip_pairs(parse_parameters)
+        _, parameters = parse_parameters
         results = parse_results
 
         Type.new(parameters:, results:)
@@ -283,7 +283,7 @@ module Wasminna
     end
 
     def parse_parameters
-      parse_declarations(kind: 'param')
+      unzip_pairs(parse_declarations(kind: 'param'))
     end
 
     def parse_results
@@ -294,7 +294,7 @@ module Wasminna
     end
 
     def parse_locals
-      parse_declarations(kind: 'local')
+      unzip_pairs(parse_declarations(kind: 'local'))
     end
 
     def parse_declarations(kind:)
@@ -317,7 +317,7 @@ module Wasminna
       read_optional_id
 
       parse_typeuse => [type_index, parameter_names]
-      local_names, locals = unzip_pairs(parse_locals)
+      local_names, locals = parse_locals
       locals_context = Context.new(locals: parameter_names + local_names)
       raise unless locals_context.well_formed?
       body, updated_typedefs =
@@ -334,7 +334,7 @@ module Wasminna
       if can_read_list?(starting_with: 'type')
         index = read_list(starting_with: 'type') { parse_index(context.types) }
       end
-      parameter_names, parameters = unzip_pairs(parse_parameters)
+      parameter_names, parameters = parse_parameters
       results = parse_results
 
       if index.nil?

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -298,7 +298,9 @@ module Wasminna
       repeatedly do
         raise StopIteration unless can_read_list?(starting_with: kind)
         read_list { parse_declaration(kind:) }
-      end.then { unzip_pairs(_1) }
+      end.transpose.then do |names = [], types = []|
+        [names, types]
+      end
     end
 
     def parse_declaration(kind:)
@@ -940,12 +942,6 @@ module Wasminna
 
     def parse_string
       string_value(read)
-    end
-
-    def unzip_pairs(pairs)
-      pairs.transpose.then do |lefts = [], rights = []|
-        [lefts, rights]
-      end
     end
   end
 end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -861,12 +861,7 @@ module Wasminna
 
         CallIndirect.new(table_index:, type_index:)
       in 'select'
-        while can_read_list?(starting_with: 'result')
-          read_list(starting_with: 'result') do
-            repeatedly { read }
-          end
-        end
-
+        parse_results
         Select.new
       in 'ref.null'
         read

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -853,7 +853,7 @@ module Wasminna
         }.fetch(opcode).new(index:)
       in 'br_table'
         indexes =
-          repeatedly(until: -> { can_read_list? || !INDEX_REGEXP.match(_1) }) do
+          repeatedly(until: -> _ { !(peek in INDEX_REGEXP) }) do
             parse_index(context.labels)
           end
         indexes => [*target_indexes, default_index]

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -843,7 +843,8 @@ module Wasminna
         }.fetch(opcode).new(index:)
       in 'br_table'
         indexes =
-          repeatedly(until: -> _ { !can_read_index? }) do
+          repeatedly do
+            raise StopIteration unless can_read_index?
             parse_index(context.labels)
           end
         indexes => [*target_indexes, default_index]
@@ -900,8 +901,11 @@ module Wasminna
     end
 
     def read_until(terminator)
-      repeatedly(until: terminator) do
-        if peek in 'block' | 'loop' | 'if'
+      repeatedly do
+        case peek
+        in ^terminator
+          raise StopIteration
+        in 'block' | 'loop' | 'if'
           [read, *read_until('end'), read]
         else
           [read]

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -100,25 +100,25 @@ module Wasminna
           read_list do
             case peek
             in 'func'
-              functions << parse_function
+              functions << parse_function_definition
             in 'memory'
-              memory = parse_memory
+              memory = parse_memory_definition
             in 'table'
-              tables << parse_table
+              tables << parse_table_definition
             in 'global'
-              globals << parse_global
+              globals << parse_global_definition
             in 'type'
-              parse_type
+              parse_type_definition
             in 'data'
-              datas << parse_data
+              datas << parse_data_segment
             in 'export'
               exports << parse_export
             in 'import'
               imports << parse_import
             in 'elem'
-              elements << parse_element
+              elements << parse_element_segment
             in 'start'
-              start = parse_start
+              start = parse_start_function
             end
           end
         end
@@ -281,7 +281,7 @@ module Wasminna
 
     ID_REGEXP = %r{\A\$}
 
-    def parse_type
+    def parse_type_definition
       read => 'type'
       if peek in ID_REGEXP
         read => ID_REGEXP => name
@@ -329,7 +329,7 @@ module Wasminna
       [name, type]
     end
 
-    def parse_function
+    def parse_function_definition
       read => 'func'
       if peek in ID_REGEXP
         read => ID_REGEXP
@@ -397,7 +397,7 @@ module Wasminna
       end
     end
 
-    def parse_memory
+    def parse_memory_definition
       read => 'memory'
       if peek in ID_REGEXP
         read => ID_REGEXP
@@ -407,7 +407,7 @@ module Wasminna
       AST::Memory.new(minimum_size:, maximum_size:)
     end
 
-    def parse_data
+    def parse_data_segment
       read => 'data'
       if peek in ID_REGEXP
         read => ID_REGEXP
@@ -443,7 +443,7 @@ module Wasminna
         \z
       }x
 
-    def parse_table
+    def parse_table_definition
       read => 'table'
       if peek in ID_REGEXP
         read => ID_REGEXP => name
@@ -468,7 +468,7 @@ module Wasminna
       [minimum_size, maximum_size]
     end
 
-    def parse_global
+    def parse_global_definition
       read => 'global'
       if peek in ID_REGEXP
         read => ID_REGEXP
@@ -535,7 +535,7 @@ module Wasminna
       Import.new(module_name:, name:, kind:, type:)
     end
 
-    def parse_element
+    def parse_element_segment
       read => 'elem'
       if peek in ID_REGEXP
         read => ID_REGEXP
@@ -568,7 +568,7 @@ module Wasminna
       ElementSegment.new(items:, mode:)
     end
 
-    def parse_start
+    def parse_start_function
       read => 'start'
       parse_index(context.functions)
     end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -62,8 +62,11 @@ module Wasminna
     def parse_binary_fields
       # TODO
       repeatedly { read }
+      functions, memories, tables, globals, types, datas, exports, imports, elements =
+        9.times.map { [] }
+      start = nil
 
-      { functions: [], memories: [], tables: [], globals: [], types: [], datas: [], exports: [], imports: [], elements: [], start: nil }
+      { functions:, memories:, tables:, globals:, types:, datas:, exports:, imports:, elements:, start: }
     end
 
     Context = Data.define(:types, :functions, :tables, :mems, :globals, :elem, :data, :locals, :labels, :typedefs) do
@@ -88,8 +91,9 @@ module Wasminna
     end
 
     def parse_text_fields
-      functions, memories, tables, globals, datas, exports, imports, elements, start =
-        [], [], [], [], [], [], [], [], nil
+      functions, memories, tables, globals, datas, exports, imports, elements =
+        8.times.map { [] }
+      start = nil
       initial_context =
         read_list(from: Marshal.load(Marshal.dump(s_expression))) do
           build_initial_context

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -287,10 +287,7 @@ module Wasminna
     end
 
     def parse_results
-      parse_declarations(kind: 'result').map do |result|
-        result => [nil, type]
-        type
-      end
+      unzip_pairs(parse_declarations(kind: 'result')).last
     end
 
     def parse_locals

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -283,22 +283,22 @@ module Wasminna
     end
 
     def parse_parameters
-      unzip_pairs(parse_declarations(kind: 'param'))
+      parse_declarations(kind: 'param')
     end
 
     def parse_results
-      unzip_pairs(parse_declarations(kind: 'result')).last
+      parse_declarations(kind: 'result').last
     end
 
     def parse_locals
-      unzip_pairs(parse_declarations(kind: 'local'))
+      parse_declarations(kind: 'local')
     end
 
     def parse_declarations(kind:)
       repeatedly do
         raise StopIteration unless can_read_list?(starting_with: kind)
         read_list { parse_declaration(kind:) }
-      end
+      end.then { unzip_pairs(_1) }
     end
 
     def parse_declaration(kind:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -856,22 +856,7 @@ module Wasminna
           else
             0
           end
-        type_index =
-          if can_read_list?(starting_with: 'type')
-            read_list(starting_with: 'type') do
-              parse_index(context.types)
-            end
-          end
-        while can_read_list?(starting_with: 'param')
-          read_list(starting_with: 'param') do
-            repeatedly { read }
-          end
-        end
-        while can_read_list?(starting_with: 'result')
-          read_list(starting_with: 'result') do
-            repeatedly { read }
-          end
-        end
+        parse_typeuse => [type_index, _]
 
         CallIndirect.new(table_index:, type_index:)
       in 'select'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -946,12 +946,8 @@ module Wasminna
     end
 
     def unzip_pairs(pairs)
-      pairs.transpose.then do |unzipped|
-        if unzipped.empty?
-          [[], []]
-        else
-          unzipped
-        end
+      pairs.transpose.then do |lefts = [], rights = []|
+        [lefts, rights]
       end
     end
   end

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -32,12 +32,10 @@ module Wasminna
         end
       end
 
-      def repeatedly(**kwargs)
-        terminator = kwargs[:until]
-
+      def repeatedly
         [].tap do |results|
           loop do
-            break if finished? || (!terminator.nil? && peek in ^terminator)
+            break if finished?
             results << yield
           end
         end

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -77,5 +77,13 @@ module Wasminna
           force_encoding(encoding)
       end
     end
+
+    module ReadOptionalId
+      private
+
+      def read_optional_id
+        read if peek in %r{\A\$}
+      end
+    end
   end
 end

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -36,7 +36,8 @@ module Wasminna
         terminator = kwargs[:until]
 
         [].tap do |results|
-          until finished? || (!terminator.nil? && peek in ^terminator)
+          loop do
+            break if finished? || (!terminator.nil? && peek in ^terminator)
             results << yield
           end
         end

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -92,10 +92,10 @@ module Wasminna
       INDEX_REGEXP =
         %r{
           \A
-          (
-            \d (_? \d)*
+          (?:
+            \d (?: _? \d)*
             |
-            0x \h (_? \h)*
+            0x \h (?: _? \h)*
             |
             \$ .+
           )

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -85,5 +85,31 @@ module Wasminna
         read if peek in %r{\A\$}
       end
     end
+
+    module ReadIndex
+      private
+
+      INDEX_REGEXP =
+        %r{
+          \A
+          (
+            \d (_? \d)*
+            |
+            0x \h (_? \h)*
+            |
+            \$ .+
+          )
+          \z
+        }x
+
+      def can_read_index?
+        peek in INDEX_REGEXP
+      end
+
+      def read_index
+        read => INDEX_REGEXP => index
+        index
+      end
+    end
   end
 end

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -139,7 +139,7 @@ module Wasminna
         build_functions(imports: mod.imports, functions: mod.functions)
       tables = build_tables(imports: mod.imports, tables: mod.tables)
       types = mod.types
-      memory = build_memory(imports: mod.imports, memory: mod.memory)
+      memory = build_memory(imports: mod.imports, memory: mod.memories.slice(0))
       globals = build_globals(imports: mod.imports, globals: mod.globals)
       exports = build_exports(functions:, globals:, tables:, memories: [memory], exports: mod.exports)
       datas = mod.datas

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -221,10 +221,11 @@ module Wasminna
       if can_read_inline_import_export?
         expand_inline_import_export(kind: 'global', id:)
       else
-        rest = repeatedly { read }
+        read => type
+        instructions = process_instructions
 
         [
-          ['global', *id, *rest]
+          ['global', *id, type, *instructions]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -96,8 +96,8 @@ module Wasminna
         process_element_segment
       in 'data'
         process_data_segment
-      else
-        [repeatedly { read }]
+      in 'export' | 'start'
+        process_unabbreviated_field
       end
     end
 
@@ -520,6 +520,15 @@ module Wasminna
 
       [
         ['data', *id, *rest]
+      ]
+    end
+
+    def process_unabbreviated_field
+      read => 'export' | 'start' => kind
+      rest = repeatedly { read }
+
+      [
+        [kind, *rest]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -378,8 +378,9 @@ module Wasminna
         if peek in ID_REGEXP
           read => ID_REGEXP => id
         end
+        typeuse = process_typeuse
 
-        ['func', *id, *process_typeuse]
+        ['func', *id, *typeuse]
       else
         repeatedly { read }
       end
@@ -484,7 +485,9 @@ module Wasminna
     end
 
     def process_function_indexes
-      repeatedly { ['ref.func', read] }
+      indexes = repeatedly { read }
+
+      indexes.map { |index| ['ref.func', index] }
     end
 
     def process_data_segment
@@ -541,7 +544,9 @@ module Wasminna
 
         ['assert_trap', mod, failure]
       else
-        ['assert_trap', *repeatedly { read }]
+        rest = repeatedly { read }
+
+        ['assert_trap', *rest]
       end
     end
   end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -247,9 +247,12 @@ module Wasminna
       read => ['import', module_name, name]
       description = repeatedly { read }
 
-      [
-        ['import', module_name, name, [kind, *id, *description]]
-      ]
+      expanded =
+        [
+          ['import', module_name, name, [kind, *id, *description]]
+        ]
+
+      read_list(from: expanded) { process_fields }
     end
 
     def expand_inline_export(kind:, id:)

--- a/lib/wasminna/s_expression_parser.rb
+++ b/lib/wasminna/s_expression_parser.rb
@@ -73,7 +73,7 @@ module Wasminna
 
     def parse_string
       read %r{"}
-      string = read %r{(\\"|[^"])*}
+      string = read %r{(?:\\"|[^"])*}
       read %r{"}
       %Q{"#{string}"}
     end

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 set -e
-export RUBY_YJIT_ENABLE=1
 
 WASMINNA_PATH=$(dirname "$0")
 if [ -z "$WASM_SPEC_PATH" ]; then

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -397,6 +397,14 @@ assert_preprocess_module_fields <<'--', <<'--'
   )
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
+  (func (import "a" "b") (type $t) (param i32 i64) (result f32 f64))
+--
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
+  (import "a" "b" (func (type $t) (param i32) (param i64) (result f32) (result f64)))
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -1,27 +1,33 @@
 assert_preprocess <<'--', <<'--'
   (module
-    (func (import "spectest" "print_i32") (param i32))
+    (type $t (func (param i32)))
+    (func (import "spectest" "print_i32") (type $t))
   )
 --
   (module
-    (import "spectest" "print_i32" (func (param i32)))
+    (type $t (func (param i32)))
+    (import "spectest" "print_i32" (func (type $t)))
   )
 --
 
 assert_preprocess <<'--', <<'--'
   (module $mymodule
-    (func (import "spectest" "print_i32") (param i32))
+    (type $t (func (param i32)))
+    (func (import "spectest" "print_i32") (type $t))
   )
 --
   (module $mymodule
-    (import "spectest" "print_i32" (func (param i32)))
+    (type $t (func (param i32)))
+    (import "spectest" "print_i32" (func (type $t)))
   )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func $myfunction (import "spectest" "print_i32") (param i32))
+  (type $t (func (param i32)))
+  (func $myfunction (import "spectest" "print_i32") (type $t))
 --
-  (import "spectest" "print_i32" (func $myfunction (param i32)))
+  (type $t (func (param i32)))
+  (import "spectest" "print_i32" (func $myfunction (type $t)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
@@ -43,50 +49,58 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
+  (type $t (func (result i32)))
+  (func (export "i32.test") (type $t) (return (i32.const 0x0bAdD00D)))
 --
+  (type $t (func (result i32)))
   (export "i32.test" (func $__fresh_0))
-  (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+  (func $__fresh_0 (type $t) (return (i32.const 0x0bAdD00D)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
-  (func (export "i32.umax") (result i32) (return (i32.const 0xffffffff)))
+  (type $t (func (result i32)))
+  (func (export "i32.test") (type $t) (return (i32.const 0x0bAdD00D)))
+  (func (export "i32.umax") (type $t) (return (i32.const 0xffffffff)))
 --
+  (type $t (func (result i32)))
   (export "i32.test" (func $__fresh_0))
-  (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+  (func $__fresh_0 (type $t) (return (i32.const 0x0bAdD00D)))
   (export "i32.umax" (func $__fresh_1))
-  (func $__fresh_1 (result i32) (return (i32.const 0xffffffff)))
+  (func $__fresh_1 (type $t) (return (i32.const 0xffffffff)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (result i32)))
   (func
     (export "i32.test1")
     (export "i32.test2")
     (export "i32.test3")
-    (result i32)
+    (type $t)
     (return (i32.const 0x0bAdD00D))
   )
 --
+  (type $t (func (result i32)))
   (export "i32.test1" (func $__fresh_0))
   (export "i32.test2" (func $__fresh_0))
   (export "i32.test3" (func $__fresh_0))
-  (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+  (func $__fresh_0 (type $t) (return (i32.const 0x0bAdD00D)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (result i32)))
   (func
     (export "i32.test1")
     (export "i32.test2")
     (export "i32.test3")
     (import "mymodule" "bad_dude")
-    (result i32)
+    (type $t)
   )
 --
+  (type $t (func (result i32)))
   (export "i32.test1" (func $__fresh_0))
   (export "i32.test2" (func $__fresh_0))
   (export "i32.test3" (func $__fresh_0))
-  (import "mymodule" "bad_dude" (func $__fresh_0 (result i32)))
+  (import "mymodule" "bad_dude" (func $__fresh_0 (type $t)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
@@ -97,50 +111,58 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
 
 assert_preprocess <<'--', <<'--'
-  (func)
+  (type $t (func))
+  (func (type $t))
   (memory 0)
-  (func (export "f"))
+  (func (export "f") (type $t))
 --
   (module
-    (func)
+    (type $t (func))
+    (func (type $t))
     (memory 0)
     (export "f" (func $__fresh_0))
-    (func $__fresh_0)
+    (func $__fresh_0 (type $t))
   )
 --
 
 assert_preprocess <<'--', <<'--'
-  (func)
+  (type $t (func))
+  (func (type $t))
   (memory 0)
-  (func (export "f"))
+  (func (export "f") (type $t))
   (invoke "f")
 --
   (module
-    (func)
+    (type $t (func))
+    (func (type $t))
     (memory 0)
     (export "f" (func $__fresh_0))
-    (func $__fresh_0)
+    (func $__fresh_0 (type $t))
   )
   (invoke "f")
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func (result i32) (local i32 f64 funcref)
+  (type $t (func (result i32)))
+  (func (type $t) (local i32 f64 funcref)
     (return (i32.const 0x0bAdD00D))
   )
 --
-  (func (result i32) (local i32) (local f64) (local funcref)
+  (type $t (func (result i32)))
+  (func (type $t) (local i32) (local f64) (local funcref)
     (return (i32.const 0x0bAdD00D))
   )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func (param i32 i64) (result i64 i32)
+  (type $t (func (param i32) (param i64) (result i64) (result i32)))
+  (func (type $t) (param i32 i64) (result i64 i32)
     (i64.const 1)
     (i32.const 2)
   )
 --
-  (func (param i32) (param i64) (result i64) (result i32)
+  (type $t (func (param i32) (param i64) (result i64) (result i32)))
+  (func (type $t) (param i32) (param i64) (result i64) (result i32)
     (i64.const 1)
     (i32.const 2)
   )
@@ -153,21 +175,27 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (import "a" "b" (func (param i32 i64) (result f32 f64)))
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
+  (import "a" "b" (func (type $t) (param i32 i64) (result f32 f64)))
 --
-  (import "a" "b" (func (param i32) (param i64) (result f32) (result f64)))
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
+  (import "a" "b" (func (type $t) (param i32) (param i64) (result f32) (result f64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func
-    (block (param i32 i32) (result i32 i32)
+  (type $t1 (func))
+  (type $t2 (func (param i32) (param i32) (result i32) (result i32)))
+  (func (type $t1)
+    (block (type $t2) (param i32 i32) (result i32 i32)
       (i32.add)
       (i32.const 1)
     )
   )
 --
-  (func
-    (block (param i32) (param i32) (result i32) (result i32)
+  (type $t1 (func))
+  (type $t2 (func (param i32) (param i32) (result i32) (result i32)))
+  (func (type $t1)
+    (block (type $t2) (param i32) (param i32) (result i32) (result i32)
       (i32.add)
       (i32.const 1)
     )
@@ -175,15 +203,25 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
-  (func
-    (call_indirect
+  (type $t1 (func))
+  (type $t2 (func
+    (param i64) (param f64) (param i32) (param i64)
+    (result f32) (result f64) (result i32))
+  )
+  (func (type $t1)
+    (call_indirect (type $t2)
       (param i64) (param) (param f64 i32 i64)
       (result f32 f64) (result i32)
     )
   )
 --
-  (func
-    (call_indirect
+  (type $t1 (func))
+  (type $t2 (func
+    (param i64) (param f64) (param i32) (param i64)
+    (result f32) (result f64) (result i32))
+  )
+  (func (type $t1)
+    (call_indirect (type $t2)
       (param i64) (param f64) (param i32) (param i64)
       (result f32) (result f64) (result i32)
     )
@@ -197,28 +235,32 @@ assert_preprocess <<'--', <<'--'
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
+  (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t)
     (offset
-      (call_indirect (param i32 i64) (result f32 f64))
+      (call_indirect (type $t1) (param i32 i64) (result f32 f64))
     )
     funcref (item ref.func $f)
   )
 --
+  (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t)
     (offset
-      (call_indirect (param i32) (param i64) (result f32) (result f64))
+      (call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64))
     )
     funcref (item ref.func $f)
   )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
+  (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (param i32 i64) (result f32 f64)))
+    (item (call_indirect (type $t1) (param i32 i64) (result f32 f64)))
   )
 --
+  (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (param i32) (param i64) (result f32) (result f64)))
+    (item (call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64)))
   )
 --
 
@@ -307,16 +349,18 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (data (memory $m)
     (offset
-      (call_indirect (param i32 i64) (result f32 f64))
+      (call_indirect (type $t) (param i32 i64) (result f32 f64))
     )
     "hello" "world"
   )
 --
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (data (memory $m)
     (offset
-      (call_indirect (param i32) (param i64) (result f32) (result f64))
+      (call_indirect (type $t) (param i32) (param i64) (result f32) (result f64))
     )
     "hello" "world"
   )

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -202,11 +202,11 @@ assert_preprocess <<'--', <<'--'
 
 assert_preprocess <<'--', <<'--'
   (module
-    (import a b (func (param i32 i64) (result f32 f64)))
+    (import "a" "b" (func (param i32 i64) (result f32 f64)))
   )
 --
   (module
-    (import a b (func (param i32) (param i64) (result f32) (result f64)))
+    (import "a" "b" (func (param i32) (param i64) (result f32) (result f64)))
   )
 --
 
@@ -214,7 +214,7 @@ assert_preprocess <<'--', <<'--'
   (module
     (func
       (block (param i32 i32) (result i32 i32)
-        (i32 add)
+        (i32.add)
         (i32.const 1)
       )
     )
@@ -223,7 +223,7 @@ assert_preprocess <<'--', <<'--'
   (module
     (func
       (block (param i32) (param i32) (result i32) (result i32)
-        (i32 add)
+        (i32.add)
         (i32.const 1)
       )
     )

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -389,6 +389,15 @@ BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'
 
+  def pretty_print(s_expression)
+    case s_expression
+    in [*items]
+      "(#{items.map { pretty_print(_1) }.join(' ')})"
+    else
+      s_expression
+    end
+  end
+
   def parse(string)
     Wasminna::SExpressionParser.new.parse(string)
   end
@@ -401,7 +410,7 @@ BEGIN {
     if actual == expected
       print "\e[32m.\e[0m"
     else
-      raise "expected #{expected}, got #{actual}"
+      raise "expected #{pretty_print(expected)}, got #{pretty_print(actual)}"
     end
   end
 

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -385,6 +385,18 @@ assert_preprocess_module_fields <<'--', <<'--'
   (data (memory $__fresh_0) (offset i32.const 0) "hello" "world")
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
+  (global $g i32
+    (call_indirect (type $t) (param i32 i64) (result f32 f64))
+  )
+--
+  (type $t (func (param i32) (param i64) (result f32) (result f64)))
+  (global $g i32
+    (call_indirect (type $t) (param i32) (param i64) (result f32) (result f64))
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -18,118 +18,82 @@ assert_preprocess <<'--', <<'--'
   )
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func $myfunction (import "spectest" "print_i32") (param i32))
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (func $myfunction (import "spectest" "print_i32") (param i32))
 --
-  (module
-    (import "spectest" "print_i32" (func $myfunction (param i32)))
-  )
+  (import "spectest" "print_i32" (func $myfunction (param i32)))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (table (import "spectest" "table") 0 funcref)
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (table (import "spectest" "table") 0 funcref)
 --
-  (module
-    (import "spectest" "table" (table 0 funcref))
-  )
+  (import "spectest" "table" (table 0 funcref))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (memory (import "spectest" "memory") 1 2)
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (memory (import "spectest" "memory") 1 2)
 --
-  (module
-    (import "spectest" "memory" (memory 1 2))
-  )
+  (import "spectest" "memory" (memory 1 2))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (global (import "spectest" "global_i32") i32)
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (global (import "spectest" "global_i32") i32)
 --
-  (module
-    (import "spectest" "global_i32" (global i32))
-  )
+  (import "spectest" "global_i32" (global i32))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
 --
-  (module
-    (export "i32.test" (func $__fresh_0))
-    (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
-  )
+  (export "i32.test" (func $__fresh_0))
+  (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
-    (func (export "i32.umax") (result i32) (return (i32.const 0xffffffff)))
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (export "i32.test") (result i32) (return (i32.const 0x0bAdD00D)))
+  (func (export "i32.umax") (result i32) (return (i32.const 0xffffffff)))
 --
-  (module
-    (export "i32.test" (func $__fresh_0))
-    (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
-    (export "i32.umax" (func $__fresh_1))
-    (func $__fresh_1 (result i32) (return (i32.const 0xffffffff)))
-  )
+  (export "i32.test" (func $__fresh_0))
+  (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
+  (export "i32.umax" (func $__fresh_1))
+  (func $__fresh_1 (result i32) (return (i32.const 0xffffffff)))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func
-      (export "i32.test1")
-      (export "i32.test2")
-      (export "i32.test3")
-      (result i32)
-      (return (i32.const 0x0bAdD00D))
-    )
+assert_preprocess_module_fields <<'--', <<'--'
+  (func
+    (export "i32.test1")
+    (export "i32.test2")
+    (export "i32.test3")
+    (result i32)
+    (return (i32.const 0x0bAdD00D))
   )
 --
-  (module
-    (export "i32.test1" (func $__fresh_0))
-    (export "i32.test2" (func $__fresh_0))
-    (export "i32.test3" (func $__fresh_0))
-    (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
-  )
+  (export "i32.test1" (func $__fresh_0))
+  (export "i32.test2" (func $__fresh_0))
+  (export "i32.test3" (func $__fresh_0))
+  (func $__fresh_0 (result i32) (return (i32.const 0x0bAdD00D)))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func
-      (export "i32.test1")
-      (export "i32.test2")
-      (export "i32.test3")
-      (import "mymodule" "bad_dude")
-      (result i32)
-    )
+assert_preprocess_module_fields <<'--', <<'--'
+  (func
+    (export "i32.test1")
+    (export "i32.test2")
+    (export "i32.test3")
+    (import "mymodule" "bad_dude")
+    (result i32)
   )
 --
-  (module
-    (export "i32.test1" (func $__fresh_0))
-    (export "i32.test2" (func $__fresh_0))
-    (export "i32.test3" (func $__fresh_0))
-    (import "mymodule" "bad_dude" (func $__fresh_0 (result i32)))
-  )
+  (export "i32.test1" (func $__fresh_0))
+  (export "i32.test2" (func $__fresh_0))
+  (export "i32.test3" (func $__fresh_0))
+  (import "mymodule" "bad_dude" (func $__fresh_0 (result i32)))
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (table (export "a") 0 1 funcref)
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (table (export "a") 0 1 funcref)
 --
-  (module
-    (export "a" (table $__fresh_0))
-    (table $__fresh_0 0 1 funcref)
-  )
+  (export "a" (table $__fresh_0))
+  (table $__fresh_0 0 1 funcref)
 --
 
 assert_preprocess <<'--', <<'--'
@@ -160,92 +124,68 @@ assert_preprocess <<'--', <<'--'
   (invoke "f")
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func (result i32) (local i32 f64 funcref)
-      (return (i32.const 0x0bAdD00D))
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (result i32) (local i32 f64 funcref)
+    (return (i32.const 0x0bAdD00D))
+  )
+--
+  (func (result i32) (local i32) (local f64) (local funcref)
+    (return (i32.const 0x0bAdD00D))
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param i32 i64) (result i64 i32)
+    (i64.const 1)
+    (i32.const 2)
+  )
+--
+  (func (param i32) (param i64) (result i64) (result i32)
+    (i64.const 1)
+    (i32.const 2)
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type (func (param i32 i64) (result f32 f64)))
+--
+  (type (func (param i32) (param i64) (result f32) (result f64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (import "a" "b" (func (param i32 i64) (result f32 f64)))
+--
+  (import "a" "b" (func (param i32) (param i64) (result f32) (result f64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func
+    (block (param i32 i32) (result i32 i32)
+      (i32.add)
+      (i32.const 1)
     )
   )
 --
-  (module
-    (func (result i32) (local i32) (local f64) (local funcref)
-      (return (i32.const 0x0bAdD00D))
+  (func
+    (block (param i32) (param i32) (result i32) (result i32)
+      (i32.add)
+      (i32.const 1)
     )
   )
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (func (param i32 i64) (result i64 i32)
-      (i64.const 1)
-      (i32.const 2)
+assert_preprocess_module_fields <<'--', <<'--'
+  (func
+    (call_indirect
+      (param i64) (param) (param f64 i32 i64)
+      (result f32 f64) (result i32)
     )
   )
 --
-  (module
-    (func (param i32) (param i64) (result i64) (result i32)
-      (i64.const 1)
-      (i32.const 2)
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (type (func (param i32 i64) (result f32 f64)))
-  )
---
-  (module
-    (type (func (param i32) (param i64) (result f32) (result f64)))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (import "a" "b" (func (param i32 i64) (result f32 f64)))
-  )
---
-  (module
-    (import "a" "b" (func (param i32) (param i64) (result f32) (result f64)))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (func
-      (block (param i32 i32) (result i32 i32)
-        (i32.add)
-        (i32.const 1)
-      )
-    )
-  )
---
-  (module
-    (func
-      (block (param i32) (param i32) (result i32) (result i32)
-        (i32.add)
-        (i32.const 1)
-      )
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (func
-      (call_indirect
-        (param i64) (param) (param f64 i32 i64)
-        (result f32 f64) (result i32)
-      )
-    )
-  )
---
-  (module
-    (func
-      (call_indirect
-        (param i64) (param f64) (param i32) (param i64)
-        (result f32) (result f64) (result i32)
-      )
+  (func
+    (call_indirect
+      (param i64) (param f64) (param i32) (param i64)
+      (result f32) (result f64) (result i32)
     )
   )
 --
@@ -256,217 +196,149 @@ assert_preprocess <<'--', <<'--'
   (module $M2 binary "\00asm" "\01\00\00\00")
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (table $t)
-      (offset
-        (call_indirect (param i32 i64) (result f32 f64))
-      )
-      funcref (item ref.func $f)
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table $t)
+    (offset
+      (call_indirect (param i32 i64) (result f32 f64))
     )
+    funcref (item ref.func $f)
   )
 --
-  (module
-    (elem (table $t)
-      (offset
-        (call_indirect (param i32) (param i64) (result f32) (result f64))
-      )
-      funcref (item ref.func $f)
+  (elem (table $t)
+    (offset
+      (call_indirect (param i32) (param i64) (result f32) (result f64))
     )
+    funcref (item ref.func $f)
   )
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (table $t) (offset i32.const 0) funcref
-      (item (call_indirect (param i32 i64) (result f32 f64)))
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table $t) (offset i32.const 0) funcref
+    (item (call_indirect (param i32 i64) (result f32 f64)))
+  )
+--
+  (elem (table $t) (offset i32.const 0) funcref
+    (item (call_indirect (param i32) (param i64) (result f32) (result f64)))
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table $t) (i32.const 0) funcref (item ref.func $f))
+--
+  (elem (table $t) (offset i32.const 0) funcref (item ref.func $f))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem funcref (ref.func $f))
+--
+  (elem funcref (item ref.func $f))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table 0) (offset i32.const 0) funcref (ref.func $f))
+--
+  (elem (table 0) (offset i32.const 0) funcref (item ref.func $f))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem declare funcref (ref.func $f))
+--
+  (elem declare funcref (item ref.func $f))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem
+    func $f $g
+  )
+--
+  (elem
+    funcref (item ref.func $f) (item ref.func $g)
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table 0) (offset i32.const 0)
+    func $f $g
+  )
+--
+  (elem (table 0) (offset i32.const 0)
+    funcref (item ref.func $f) (item ref.func $g)
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem declare
+    func $f $g
+  )
+--
+  (elem declare
+    funcref (item ref.func $f) (item ref.func $g)
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (offset i32.const 0) funcref (item ref.func $f))
+--
+  (elem (table 0) (offset i32.const 0) funcref (item ref.func $f))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (offset i32.const 0)
+    $f $g
+  )
+--
+  (elem (table 0) (offset i32.const 0)
+    funcref (item ref.func $f) (item ref.func $g)
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (table $t funcref (elem (item ref.func $f) (item ref.func $g)))
+--
+  (table $t 2 2 funcref)
+  (elem (table $t) (offset i32.const 0) funcref (item ref.func $f) (item ref.func $g))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (table $t funcref (elem $f $g))
+--
+  (table $t 2 2 funcref)
+  (elem (table $t) (offset i32.const 0) funcref (item ref.func $f) (item ref.func $g))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (data (memory $m)
+    (offset
+      (call_indirect (param i32 i64) (result f32 f64))
     )
+    "hello" "world"
   )
 --
-  (module
-    (elem (table $t) (offset i32.const 0) funcref
-      (item (call_indirect (param i32) (param i64) (result f32) (result f64)))
+  (data (memory $m)
+    (offset
+      (call_indirect (param i32) (param i64) (result f32) (result f64))
     )
+    "hello" "world"
   )
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (table $t) (i32.const 0) funcref (item ref.func $f))
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (data $d (memory $m) (i32.const 0) "hello" "world")
 --
-  (module
-    (elem (table $t) (offset i32.const 0) funcref (item ref.func $f))
-  )
+  (data $d (memory $m) (offset i32.const 0) "hello" "world")
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem funcref (ref.func $f))
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (data $d (offset i32.const 0) "hello" "world")
 --
-  (module
-    (elem funcref (item ref.func $f))
-  )
+  (data $d (memory 0) (offset i32.const 0) "hello" "world")
 --
 
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (table 0) (offset i32.const 0) funcref (ref.func $f))
-  )
+assert_preprocess_module_fields <<'--', <<'--'
+  (memory (data "hello" "world"))
 --
-  (module
-    (elem (table 0) (offset i32.const 0) funcref (item ref.func $f))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem declare funcref (ref.func $f))
-  )
---
-  (module
-    (elem declare funcref (item ref.func $f))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem
-      func $f $g
-    )
-  )
---
-  (module
-    (elem
-      funcref (item ref.func $f) (item ref.func $g)
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (table 0) (offset i32.const 0)
-      func $f $g
-    )
-  )
---
-  (module
-    (elem (table 0) (offset i32.const 0)
-      funcref (item ref.func $f) (item ref.func $g)
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem declare
-      func $f $g
-    )
-  )
---
-  (module
-    (elem declare
-      funcref (item ref.func $f) (item ref.func $g)
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (offset i32.const 0) funcref (item ref.func $f))
-  )
---
-  (module
-    (elem (table 0) (offset i32.const 0) funcref (item ref.func $f))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (elem (offset i32.const 0)
-      $f $g
-    )
-  )
---
-  (module
-    (elem (table 0) (offset i32.const 0)
-      funcref (item ref.func $f) (item ref.func $g)
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (table $t funcref (elem (item ref.func $f) (item ref.func $g)))
-  )
---
-  (module
-    (table $t 2 2 funcref)
-    (elem (table $t) (offset i32.const 0) funcref (item ref.func $f) (item ref.func $g))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (table $t funcref (elem $f $g))
-  )
---
-  (module
-    (table $t 2 2 funcref)
-    (elem (table $t) (offset i32.const 0) funcref (item ref.func $f) (item ref.func $g))
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (data (memory $m)
-      (offset
-        (call_indirect (param i32 i64) (result f32 f64))
-      )
-      "hello" "world"
-    )
-  )
---
-  (module
-    (data (memory $m)
-      (offset
-        (call_indirect (param i32) (param i64) (result f32) (result f64))
-      )
-      "hello" "world"
-    )
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (data $d (memory $m) (i32.const 0) "hello" "world")
-  )
---
-  (module
-    (data $d (memory $m) (offset i32.const 0) "hello" "world")
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (data $d (offset i32.const 0) "hello" "world")
-  )
---
-  (module
-    (data $d (memory 0) (offset i32.const 0) "hello" "world")
-  )
---
-
-assert_preprocess <<'--', <<'--'
-  (module
-    (memory (data "hello" "world"))
-  )
---
-  (module
-    (memory $__fresh_0 1 1)
-    (data (memory $__fresh_0) (offset i32.const 0) "hello" "world")
-  )
+  (memory $__fresh_0 1 1)
+  (data (memory $__fresh_0) (offset i32.const 0) "hello" "world")
 --
 
 BEGIN {
@@ -487,6 +359,10 @@ BEGIN {
     else
       raise "expected #{expected}, got #{actual}"
     end
+  end
+
+  def assert_preprocess_module_fields(input, expected)
+    assert_preprocess "(module #{input})", "(module #{expected})"
   end
 }
 


### PR DESCRIPTION
The preprocessor and parser (and their tests) were becoming a little messy and inconsistent. This PR cleans them up to fix many minor annoyances in preparation for implementing the type use abbreviation.

The problems addressed are mostly related to naming and code organisation. The most significant change is that the instructions inside a global definition’s initialiser expression and the expanded result of an inline import are now being preprocessed correctly; I’d previously overlooked the need to do this because neither case is exercised by the WebAssembly test suite for any of the abbreviations implemented so far.