### PR TITLE
Preprocess only genuine type uses inside instructions

### DIFF
--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -4,6 +4,7 @@ require 'wasminna/memory'
 module Wasminna
   class Preprocessor
     include Helpers::ReadFromSExpression
+    include Helpers::ReadIndex
     include Helpers::ReadOptionalId
     include Helpers::SizeOf
     include Helpers::StringValue
@@ -304,6 +305,14 @@ module Wasminna
           blocktype = process_blocktype
 
           [kind, *id, *blocktype]
+        in 'call_indirect'
+          read => 'call_indirect'
+          if can_read_index?
+            read_index => index
+          end
+          typeuse = process_typeuse
+
+          ['call_indirect', *index, *typeuse]
         in 'select'
           read => 'select'
           results = process_results

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -297,8 +297,6 @@ module Wasminna
     def process_instructions
       repeatedly do
         case peek
-        in ['param' | 'result', *]
-          process_typeuse
         in 'block' | 'loop' | 'if'
           read => 'block' | 'loop' | 'if' => kind
           read_optional_id => id

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -296,17 +296,17 @@ module Wasminna
     def process_instructions
       repeatedly do
         if can_read_list?
-          read_list do
-            case peek
-            in 'param' | 'result'
+          case peek
+          in ['param' | 'result', *]
+            read_list do
               read => 'param' | 'result' => kind
               repeatedly do
                 read => type
                 [kind, type]
               end
-            else
-              [process_instructions]
             end
+          else
+            read_list { [process_instructions] }
           end
         else
           [read]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -326,7 +326,12 @@ module Wasminna
       results = process_results
       blocktype = [*type, *parameters, *results]
 
-      read_list(from: blocktype) { process_typeuse }
+      case blocktype
+      in []
+        blocktype
+      else
+        read_list(from: blocktype) { process_typeuse }
+      end
     end
 
     def process_instruction

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -327,7 +327,7 @@ module Wasminna
       blocktype = [*type, *parameters, *results]
 
       case blocktype
-      in []
+      in [] | [['result', _]]
         blocktype
       else
         read_list(from: blocktype) { process_typeuse }

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -318,7 +318,15 @@ module Wasminna
     end
 
     def process_blocktype
-      process_typeuse
+      type =
+        if can_read_list?(starting_with: 'type')
+          [read]
+        end
+      parameters = process_parameters
+      results = process_results
+      blocktype = [*type, *parameters, *results]
+
+      read_list(from: blocktype) { process_typeuse }
     end
 
     def process_instruction

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -295,19 +295,17 @@ module Wasminna
 
     def process_instructions
       repeatedly do
-        if can_read_list?
-          case peek
-          in ['param' | 'result', *]
-            read_list do
-              read => 'param' | 'result' => kind
-              repeatedly do
-                read => type
-                [kind, type]
-              end
+        case peek
+        in ['param' | 'result', *]
+          read_list do
+            read => 'param' | 'result' => kind
+            repeatedly do
+              read => type
+              [kind, type]
             end
-          else
-            read_list { [process_instructions] }
           end
+        in [*]
+          read_list { [process_instructions] }
         else
           [read]
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -298,6 +298,11 @@ module Wasminna
         case peek
         in ['param' | 'result', *]
           process_typeuse
+        in 'select'
+          read => 'select'
+          results = process_results
+
+          ['select', *results]
         in [*]
           read_list { [process_instructions] }
         else

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -298,6 +298,12 @@ module Wasminna
         case peek
         in ['param' | 'result', *]
           process_typeuse
+        in 'block' | 'loop' | 'if'
+          read => 'block' | 'loop' | 'if' => kind
+          read_optional_id => id
+          blocktype = process_blocktype
+
+          [kind, *id, *blocktype]
         in 'select'
           read => 'select'
           results = process_results
@@ -309,6 +315,10 @@ module Wasminna
           [read]
         end
       end.flatten(1)
+    end
+
+    def process_blocktype
+      process_typeuse
     end
 
     def process_instruction

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -297,13 +297,7 @@ module Wasminna
       repeatedly do
         case peek
         in ['param' | 'result', *]
-          read_list do
-            read => 'param' | 'result' => kind
-            repeatedly do
-              read => type
-              [kind, type]
-            end
-          end
+          process_typeuse
         in [*]
           read_list { [process_instructions] }
         else

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -481,6 +481,42 @@ assert_preprocess_module_fields <<'--', <<'--'
   )
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    (block (result i64)
+      (i64.const 1)
+    )
+  )
+  (type (func (result i64)))
+--
+  (type $t (func))
+  (func (type $t)
+    (block (result i64)
+      (i64.const 1)
+    )
+  )
+  (type (func (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    (block (param) (result i64)
+      (i64.const 1)
+    )
+  )
+  (type (func (result i64)))
+--
+  (type $t (func))
+  (func (type $t)
+    (block (result i64)
+      (i64.const 1)
+    )
+  )
+  (type (func (result i64)))
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -517,6 +517,24 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type (func (result i64)))
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t1 (func (param i32) (result i32)))
+  (type $t2 (func (param i32) (param i64) (result f32) (result f64)))
+  (func (type $t1)
+    call_indirect (type $t2) (param i32 i64) (result f32 f64)
+    i32.const 1
+    i32.add
+  )
+--
+  (type $t1 (func (param i32) (result i32)))
+  (type $t2 (func (param i32) (param i64) (result f32) (result f64)))
+  (func (type $t1)
+    call_indirect (type $t2) (param i32) (param i64) (result f32) (result f64)
+    i32.const 1
+    i32.add
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -457,6 +457,30 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type (func (result i32) (result i32)))
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    (block)
+  )
+--
+  (type $t (func))
+  (func (type $t)
+    (block)
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    (block (result))
+  )
+--
+  (type $t (func))
+  (func (type $t)
+    (block)
+  )
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -405,6 +405,58 @@ assert_preprocess_module_fields <<'--', <<'--'
   (import "a" "b" (func (type $t) (param i32) (param i64) (result f32) (result f64)))
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (param i32) (param i32) (param i32) (result i32)))
+  (func (type $t)
+    (select (result i32 i32) (local.get 0) (local.get 1) (local.get 2))
+  )
+  (type (func (result i32) (result i32)))
+--
+  (type $t (func (param i32) (param i32) (param i32) (result i32)))
+  (func (type $t)
+    (select (result i32) (result i32) (local.get 0) (local.get 1) (local.get 2))
+  )
+  (type (func (result i32) (result i32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (param i32) (param i32) (param i32) (result i32)))
+  (func (type $t)
+    (select (result i32 i32) (local.get 0) (local.get 1) (local.get 2) (i32.const 1) (i32.add))
+  )
+  (type (func (result i32) (result i32)))
+--
+  (type $t (func (param i32) (param i32) (param i32) (result i32)))
+  (func (type $t)
+    (select (result i32) (result i32) (local.get 0) (local.get 1) (local.get 2) (i32.const 1) (i32.add))
+  )
+  (type (func (result i32) (result i32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func (param i32) (param i32) (param i32) (result i32)))
+  (func (type $t)
+    local.get 0
+    local.get 1
+    local.get 2
+    select (result i32 i32)
+    i32.const 1
+    i32.add
+  )
+  (type (func (result i32) (result i32)))
+--
+  (type $t (func (param i32) (param i32) (param i32) (result i32)))
+  (func (type $t)
+    local.get 0
+    local.get 1
+    local.get 2
+    select (result i32) (result i32)
+    i32.const 1
+    i32.add
+  )
+  (type (func (result i32) (result i32)))
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
As described in d0f567570c3740ed84c9da881cf1652a6ccac047, [type uses](https://webassembly.github.io/spec/core/text/modules.html#type-uses) can appear inside a few different kinds of instruction (`block`, `loop`, `if` and `call_indirect`) so we need to find and preprocess them to make it possible to add support for the [type use abbreviation](https://webassembly.github.io/spec/core/text/modules.html#abbreviations) in future.

Our previous implementation was hacky and depended upon finding every syntactic occurrence of `param` and `result` inside an instruction and desugaring [multiple anonymous occurrences](https://webassembly.github.io/spec/core/text/types.html#abbreviations). This is fine for that specific abbreviation but unsuitable for type uses more generally because some occurrences of `result` aren’t type uses: a `select` instruction uses `result` but that isn’t a type use, and a [block type](https://webassembly.github.io/spec/core/text/instructions.html#text-blocktype) may or may not contain a type use depending upon whether `type` and `param` appear and how many `result`s it has.

This PR refines the implementation to correctly identify and preprocess only genuine type uses, taking into account the rules for when a block type should be treated as a type use.