### PR TITLE
Allow type definitions to be provided after preprocessing a module

### DIFF
--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -304,20 +304,20 @@ module Wasminna
         in 'block' | 'loop' | 'if'
           read => 'block' | 'loop' | 'if' => kind
           read_optional_id => id
-          blocktype = process_blocktype.call(DUMMY_TYPE_DEFINITIONS)
+          blocktype = process_blocktype
 
-          after_all_fields do
-            [kind, *id, *blocktype]
+          after_all_fields do |type_definitions|
+            [kind, *id, *blocktype.call(type_definitions)]
           end
         in 'call_indirect'
           read => 'call_indirect'
           if can_read_index?
             read_index => index
           end
-          typeuse = process_typeuse.call(DUMMY_TYPE_DEFINITIONS)
+          typeuse = process_typeuse
 
-          after_all_fields do
-            ['call_indirect', *index, *typeuse]
+          after_all_fields do |type_definitions|
+            ['call_indirect', *index, *typeuse.call(type_definitions)]
           end
         in 'select'
           read => 'select'

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -560,7 +560,7 @@ module Wasminna
       if can_read_list?
         process_active_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
-        process_passive_data_segment(id:)
+        process_passive_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       end
     end
 
@@ -584,9 +584,11 @@ module Wasminna
     def process_passive_data_segment(id:)
       rest = repeatedly { read }
 
-      [
-        ['data', *id, *rest]
-      ]
+      after_all_fields do
+        [
+          ['data', *id, *rest]
+        ]
+      end
     end
 
     def process_unabbreviated_field

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -120,17 +120,9 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'table', id:).call(DUMMY_TYPE_DEFINITIONS) .then do |result|
-          after_all_fields do
-            result
-          end
-        end
+        expand_inline_import_export(kind: 'table', id:)
       elsif can_read_inline_element_segment?
-        expand_inline_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
-          after_all_fields do
-            result
-          end
-        end
+        expand_inline_element_segment(id:)
       else
         rest = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -470,13 +470,13 @@ module Wasminna
       instructions =
         if peek in 'offset'
           read => 'offset'
-          process_instructions.call(DUMMY_TYPE_DEFINITIONS)
+          process_instructions
         else
-          process_instruction.call(DUMMY_TYPE_DEFINITIONS)
+          process_instruction
         end
 
-      after_all_fields do
-        ['offset', *instructions]
+      after_all_fields do |type_definitions|
+        ['offset', *instructions.call(type_definitions)]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -451,16 +451,16 @@ module Wasminna
         if can_read_list?(starting_with: 'table')
           read
         end
-      offset = read_list { process_offset.call(DUMMY_TYPE_DEFINITIONS) }
-      element_list = process_element_list(func_optional: table_use.nil?).call(DUMMY_TYPE_DEFINITIONS)
+      offset = read_list { process_offset }
+      element_list = process_element_list(func_optional: table_use.nil?)
 
       if table_use.nil?
         table_use = %w[table 0]
       end
 
-      after_all_fields do
+      after_all_fields do |type_definitions|
         [
-          ['elem', *id, table_use, offset, *element_list]
+          ['elem', *id, table_use, offset.call(type_definitions), *element_list.call(type_definitions)]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -437,7 +437,7 @@ module Wasminna
         if can_read_list?(starting_with: 'table')
           read
         end
-      offset = read_list { process_offset }
+      offset = read_list { process_offset.call(DUMMY_TYPE_DEFINITIONS) }
       element_list = process_element_list(func_optional: table_use.nil?)
 
       if table_use.nil?
@@ -475,7 +475,9 @@ module Wasminna
           process_instruction.call(DUMMY_TYPE_DEFINITIONS)
         end
 
-      ['offset', *instructions]
+      after_all_fields do
+        ['offset', *instructions]
+      end
     end
 
     def process_element_list(func_optional:)
@@ -545,7 +547,7 @@ module Wasminna
         else
           %w[memory 0]
         end
-      offset = read_list { process_offset }
+      offset = read_list { process_offset.call(DUMMY_TYPE_DEFINITIONS) }
       strings = repeatedly { read }
 
       [

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -499,13 +499,13 @@ module Wasminna
       instructions =
         if peek in 'item'
           read => 'item'
-          process_instructions.call(DUMMY_TYPE_DEFINITIONS)
+          process_instructions
         else
-          process_instruction.call(DUMMY_TYPE_DEFINITIONS)
+          process_instruction
         end
 
-      after_all_fields do
-        ['item', *instructions]
+      after_all_fields do |type_definitions|
+        ['item', *instructions.call(type_definitions)]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -206,11 +206,7 @@ module Wasminna
           ['data', ['memory', id], %w[i32.const 0], *strings]
         ]
 
-      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
-        after_all_fields do
-          result
-        end
-      end
+      read_list(from: expanded) { process_fields }
     end
 
     def process_global_definition

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -224,7 +224,7 @@ module Wasminna
       in ['import', _, _]
         expand_inline_import(**).call(DUMMY_TYPE_DEFINITIONS)
       in ['export', _]
-        expand_inline_export(**)
+        expand_inline_export(**).call(DUMMY_TYPE_DEFINITIONS)
       end
     end
 
@@ -257,7 +257,11 @@ module Wasminna
           [kind, id, *description]
         ]
 
-      read_list(from: expanded) { process_fields }
+      read_list(from: expanded) { process_fields }.then do |result|
+        after_all_fields do
+          result
+        end
+      end
     end
 
     def process_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -343,9 +343,7 @@ module Wasminna
           blocktype
         end
       else
-        after_all_fields do
-          read_list(from: blocktype) { process_typeuse.call(DUMMY_TYPE_DEFINITIONS) }
-        end
+        read_list(from: blocktype) { process_typeuse }
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -473,7 +473,7 @@ module Wasminna
     def process_element_list(func_optional:)
       if peek in 'funcref' | 'externref'
         read => 'funcref' | 'externref' => reftype
-        items = process_element_expressions
+        items = process_element_expressions.call(DUMMY_TYPE_DEFINITIONS)
 
         [reftype, *items]
       else
@@ -482,7 +482,7 @@ module Wasminna
         end
         items =
           read_list(from: process_function_indexes) do
-            process_element_expressions
+            process_element_expressions.call(DUMMY_TYPE_DEFINITIONS)
           end
 
         ['funcref', *items]
@@ -492,6 +492,10 @@ module Wasminna
     def process_element_expressions
       repeatedly do
         read_list { process_element_expression.call(DUMMY_TYPE_DEFINITIONS) }
+      end.then do |results|
+        after_all_fields do
+          results
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -82,7 +82,7 @@ module Wasminna
       in 'memory'
         process_memory_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'global'
-        process_global_definition
+        process_global_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'type'
         process_type_definition
       in 'import'
@@ -218,14 +218,20 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'global', id:).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_import_export(kind: 'global', id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
+          after_all_fields do
+            result
+          end
+        end
       else
         read => type
         instructions = process_instructions.call(DUMMY_TYPE_DEFINITIONS)
 
-        [
-          ['global', *id, type, *instructions]
-        ]
+        after_all_fields do
+          [
+            ['global', *id, type, *instructions]
+          ]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -88,7 +88,7 @@ module Wasminna
       in 'import'
         process_import.call(DUMMY_TYPE_DEFINITIONS)
       in 'elem'
-        process_element_segment
+        process_element_segment.call(DUMMY_TYPE_DEFINITIONS)
       in 'data'
         process_data_segment
       in 'export' | 'start'
@@ -450,11 +450,11 @@ module Wasminna
       read_optional_id => id
 
       if can_read_list?
-        process_active_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        process_active_element_segment(id:)
       elsif peek in 'declare'
-        process_declarative_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        process_declarative_element_segment(id:)
       else
-        process_passive_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        process_passive_element_segment(id:)
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -340,8 +340,8 @@ module Wasminna
           end
         end
       end.then do |results|
-        after_all_fields do
-          results.flat_map { |result| result.call(DUMMY_TYPE_DEFINITIONS) }
+        after_all_fields do |type_definitions|
+          results.flat_map { |result| result.call(type_definitions) }
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -172,7 +172,7 @@ module Wasminna
       if can_read_inline_import_export?
         expand_inline_import_export(kind: 'memory', id:)
       elsif can_read_inline_data_segment?
-        expand_inline_data_segment(id:)
+        expand_inline_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
         rest = repeatedly { read }
 
@@ -200,7 +200,11 @@ module Wasminna
           ['data', ['memory', id], %w[i32.const 0], *strings]
         ]
 
-      read_list(from: expanded) { process_fields }
+      read_list(from: expanded) { process_fields }.then do |result|
+        after_all_fields do
+          result
+        end
+      end
     end
 
     def process_global_definition

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -366,7 +366,7 @@ module Wasminna
     end
 
     def process_instruction
-      process_instructions.call(DUMMY_TYPE_DEFINITIONS) # TODO only process one instruction
+      process_instructions # TODO only process one instruction
     end
 
     def process_type_definition
@@ -464,7 +464,7 @@ module Wasminna
           read => 'offset'
           process_instructions.call(DUMMY_TYPE_DEFINITIONS)
         else
-          process_instruction
+          process_instruction.call(DUMMY_TYPE_DEFINITIONS)
         end
 
       ['offset', *instructions]
@@ -501,7 +501,7 @@ module Wasminna
           read => 'item'
           process_instructions.call(DUMMY_TYPE_DEFINITIONS)
         else
-          process_instruction
+          process_instruction.call(DUMMY_TYPE_DEFINITIONS)
         end
 
       ['item', *instructions]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -467,11 +467,11 @@ module Wasminna
 
     def process_declarative_element_segment(id:)
       read => 'declare'
-      element_list = process_element_list(func_optional: false).call(DUMMY_TYPE_DEFINITIONS)
+      element_list = process_element_list(func_optional: false)
 
-      after_all_fields do
+      after_all_fields do |type_definitions|
         [
-          ['elem', *id, 'declare', *element_list]
+          ['elem', *id, 'declare', *element_list.call(type_definitions)]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -80,7 +80,7 @@ module Wasminna
       in 'table'
         process_table_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'memory'
-        process_memory_definition
+        process_memory_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'global'
         process_global_definition
       in 'type'
@@ -174,15 +174,25 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'memory', id:).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_import_export(kind: 'memory', id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
+          after_all_fields do
+            result
+          end
+        end
       elsif can_read_inline_data_segment?
-        expand_inline_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
+          after_all_fields do
+            result
+          end
+        end
       else
         rest = repeatedly { read }
 
-        [
-          ['memory', *id, *rest]
-        ]
+        after_all_fields do
+          [
+            ['memory', *id, *rest]
+          ]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -62,7 +62,7 @@ module Wasminna
         strings = repeatedly { read }
         ['module', *id, 'binary', *strings]
       else
-        fields = process_fields
+        fields = process_fields.call(DUMMY_TYPE_DEFINITIONS)
         ['module', *id, *fields]
       end
     end
@@ -70,7 +70,11 @@ module Wasminna
     def process_fields
       repeatedly do
         read_list { process_field.call(DUMMY_TYPE_DEFINITIONS) }
-      end.flatten(1)
+      end.flatten(1).then do |result|
+        after_all_fields do
+          result
+        end
+      end
     end
 
     def process_field
@@ -162,7 +166,7 @@ module Wasminna
           ['elem', ['table', id], %w[i32.const 0], item_type, *items]
         ]
 
-      read_list(from: expanded) { process_fields }.then do |result|
+      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
         after_all_fields do
           result
         end
@@ -206,7 +210,7 @@ module Wasminna
           ['data', ['memory', id], %w[i32.const 0], *strings]
         ]
 
-      read_list(from: expanded) { process_fields }.then do |result|
+      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
         after_all_fields do
           result
         end
@@ -253,7 +257,7 @@ module Wasminna
           ['import', module_name, name, [kind, *id, *description]]
         ]
 
-      read_list(from: expanded) { process_fields }.then do |result|
+      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
         after_all_fields do
           result
         end
@@ -273,7 +277,7 @@ module Wasminna
           [kind, id, *description]
         ]
 
-      read_list(from: expanded) { process_fields }.then do |result|
+      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
         after_all_fields do
           result
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -442,7 +442,7 @@ module Wasminna
       elsif peek in 'declare'
         process_declarative_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
-        process_passive_element_segment(id:)
+        process_passive_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       end
     end
 
@@ -479,9 +479,11 @@ module Wasminna
     def process_passive_element_segment(id:)
       element_list = process_element_list(func_optional: false).call(DUMMY_TYPE_DEFINITIONS)
 
-      [
-        ['elem', *id, *element_list]
-      ]
+      after_all_fields do
+        [
+          ['elem', *id, *element_list]
+        ]
+      end
     end
 
     def process_offset

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -419,10 +419,10 @@ module Wasminna
       when 'func'
         read => 'func'
         read_optional_id => id
-        typeuse = process_typeuse.call(DUMMY_TYPE_DEFINITIONS)
+        typeuse = process_typeuse
 
-        after_all_fields do
-          ['func', *id, *typeuse]
+        after_all_fields do |type_definitions|
+          ['func', *id, *typeuse.call(type_definitions)]
         end
       else
         repeatedly { read }.then do |result|

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -71,8 +71,8 @@ module Wasminna
       repeatedly do
         read_list { process_field }
       end.then do |fields|
-        after_all_fields do
-          fields.flat_map { |field| field.call(DUMMY_TYPE_DEFINITIONS) }
+        after_all_fields do |type_definitions|
+          fields.flat_map { |field| field.call(type_definitions) }
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -120,7 +120,7 @@ module Wasminna
       if can_read_inline_import_export?
         expand_inline_import_export(kind: 'table', id:)
       elsif can_read_inline_element_segment?
-        expand_inline_element_segment(id:)
+        expand_inline_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
         rest = repeatedly { read }
 
@@ -158,7 +158,11 @@ module Wasminna
           ['elem', ['table', id], %w[i32.const 0], item_type, *items]
         ]
 
-      read_list(from: expanded) { process_fields }
+      read_list(from: expanded) { process_fields }.then do |result|
+        after_all_fields do
+          result
+        end
+      end
     end
 
     def process_memory_definition

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -249,11 +249,7 @@ module Wasminna
           ['import', module_name, name, [kind, *id, *description]]
         ]
 
-      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
-        after_all_fields do
-          result
-        end
-      end
+      read_list(from: expanded) { process_fields }
     end
 
     def expand_inline_export(kind:, id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -222,7 +222,7 @@ module Wasminna
     def expand_inline_import_export(**)
       case peek
       in ['import', _, _]
-        expand_inline_import(**)
+        expand_inline_import(**).call(DUMMY_TYPE_DEFINITIONS)
       in ['export', _]
         expand_inline_export(**)
       end
@@ -237,7 +237,11 @@ module Wasminna
           ['import', module_name, name, [kind, *id, *description]]
         ]
 
-      read_list(from: expanded) { process_fields }
+      read_list(from: expanded) { process_fields }.then do |result|
+        after_all_fields do
+          result
+        end
+      end
     end
 
     def expand_inline_export(kind:, id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -84,7 +84,7 @@ module Wasminna
       in 'global'
         process_global_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'type'
-        process_type_definition
+        process_type_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'import'
         process_import
       in 'elem'
@@ -398,9 +398,11 @@ module Wasminna
       read_optional_id => id
       functype = read_list { process_functype }
 
-      [
-        ['type', *id, functype]
-      ]
+      after_all_fields do
+        [
+          ['type', *id, functype]
+        ]
+      end
     end
 
     def process_functype

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -265,11 +265,7 @@ module Wasminna
           [kind, id, *description]
         ]
 
-      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
-        after_all_fields do
-          result
-        end
-      end
+      read_list(from: expanded) { process_fields }
     end
 
     def process_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -571,12 +571,12 @@ module Wasminna
         else
           %w[memory 0]
         end
-      offset = read_list { process_offset.call(DUMMY_TYPE_DEFINITIONS) }
+      offset = read_list { process_offset }
       strings = repeatedly { read }
 
-      after_all_fields do
+      after_all_fields do |type_definitions|
         [
-          ['data', *id, memory_use, offset, *strings]
+          ['data', *id, memory_use, offset.call(type_definitions), *strings]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -327,9 +327,9 @@ module Wasminna
             ['select', *results]
           end
         in [*]
-          read_list { process_instructions.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
-            after_all_fields do
-              [result]
+          read_list { process_instructions }.then do |result|
+            after_all_fields do |type_definitions|
+              [result.call(type_definitions)]
             end
           end
         else

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -417,11 +417,11 @@ module Wasminna
       read => 'import'
       read => module_name
       read => name
-      descriptor = read_list { process_import_descriptor.call(DUMMY_TYPE_DEFINITIONS) }
+      descriptor = read_list { process_import_descriptor }
 
-      after_all_fields do
+      after_all_fields do |type_definitions|
         [
-          ['import', module_name, name, descriptor]
+          ['import', module_name, name, descriptor.call(type_definitions)]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -90,7 +90,7 @@ module Wasminna
       in 'elem'
         process_element_segment.call(DUMMY_TYPE_DEFINITIONS)
       in 'data'
-        process_data_segment
+        process_data_segment.call(DUMMY_TYPE_DEFINITIONS)
       in 'export' | 'start'
         process_unabbreviated_field
       end
@@ -570,9 +570,9 @@ module Wasminna
       read_optional_id => id
 
       if can_read_list?
-        process_active_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        process_active_data_segment(id:)
       else
-        process_passive_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        process_passive_data_segment(id:)
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -558,7 +558,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_list?
-        process_active_data_segment(id:)
+        process_active_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
         process_passive_data_segment(id:)
       end
@@ -574,9 +574,11 @@ module Wasminna
       offset = read_list { process_offset.call(DUMMY_TYPE_DEFINITIONS) }
       strings = repeatedly { read }
 
-      [
-        ['data', *id, memory_use, offset, *strings]
-      ]
+      after_all_fields do
+        [
+          ['data', *id, memory_use, offset, *strings]
+        ]
+      end
     end
 
     def process_passive_data_segment(id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -304,7 +304,7 @@ module Wasminna
         in 'block' | 'loop' | 'if'
           read => 'block' | 'loop' | 'if' => kind
           read_optional_id => id
-          blocktype = process_blocktype
+          blocktype = process_blocktype.call(DUMMY_TYPE_DEFINITIONS)
 
           [kind, *id, *blocktype]
         in 'call_indirect'
@@ -339,9 +339,13 @@ module Wasminna
 
       case blocktype
       in [] | [['result', _]]
-        blocktype
+        after_all_fields do
+          blocktype
+        end
       else
-        read_list(from: blocktype) { process_typeuse.call(DUMMY_TYPE_DEFINITIONS) }
+        after_all_fields do
+          read_list(from: blocktype) { process_typeuse.call(DUMMY_TYPE_DEFINITIONS) }
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -483,10 +483,10 @@ module Wasminna
     def process_element_list(func_optional:)
       if peek in 'funcref' | 'externref'
         read => 'funcref' | 'externref' => reftype
-        items = process_element_expressions.call(DUMMY_TYPE_DEFINITIONS)
+        items = process_element_expressions
 
-        after_all_fields do
-          [reftype, *items]
+        after_all_fields do |type_definitions|
+          [reftype, *items.call(type_definitions)]
         end
       else
         if !func_optional || (peek in 'func')
@@ -494,11 +494,11 @@ module Wasminna
         end
         items =
           read_list(from: process_function_indexes) do
-            process_element_expressions.call(DUMMY_TYPE_DEFINITIONS)
+            process_element_expressions
           end
 
-        after_all_fields do
-          ['funcref', *items]
+        after_all_fields do |type_definitions|
+          ['funcref', *items.call(type_definitions)]
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -69,10 +69,10 @@ module Wasminna
 
     def process_fields
       repeatedly do
-        read_list { process_field.call(DUMMY_TYPE_DEFINITIONS) }
-      end.flatten(1).then do |result|
+        read_list { process_field }
+      end.then do |fields|
         after_all_fields do
-          result
+          fields.flat_map { |field| field.call(DUMMY_TYPE_DEFINITIONS) }
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -407,7 +407,7 @@ module Wasminna
       read => 'import'
       read => module_name
       read => name
-      descriptor = read_list { process_import_descriptor }
+      descriptor = read_list { process_import_descriptor.call(DUMMY_TYPE_DEFINITIONS) }
 
       [
         ['import', module_name, name, descriptor]
@@ -421,9 +421,15 @@ module Wasminna
         read_optional_id => id
         typeuse = process_typeuse.call(DUMMY_TYPE_DEFINITIONS)
 
-        ['func', *id, *typeuse]
+        after_all_fields do
+          ['func', *id, *typeuse]
+        end
       else
-        repeatedly { read }
+        repeatedly { read }.then do |result|
+          after_all_fields do
+            result
+          end
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -491,10 +491,10 @@ module Wasminna
 
     def process_element_expressions
       repeatedly do
-        read_list { process_element_expression.call(DUMMY_TYPE_DEFINITIONS) }
+        read_list { process_element_expression }
       end.then do |results|
-        after_all_fields do
-          results
+        after_all_fields do |type_definitions|
+          results.map { |result| result.call(type_definitions) }
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -78,7 +78,7 @@ module Wasminna
       in 'func'
         process_function_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'table'
-        process_table_definition
+        process_table_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'memory'
         process_memory_definition
       in 'global'
@@ -120,15 +120,25 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'table', id:).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_import_export(kind: 'table', id:).call(DUMMY_TYPE_DEFINITIONS) .then do |result|
+          after_all_fields do
+            result
+          end
+        end
       elsif can_read_inline_element_segment?
-        expand_inline_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
+          after_all_fields do
+            result
+          end
+        end
       else
         rest = repeatedly { read }
 
-        [
-          ['table', *id, *rest]
-        ]
+        after_all_fields do
+          [
+            ['table', *id, *rest]
+          ]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -86,7 +86,7 @@ module Wasminna
       in 'type'
         process_type_definition.call(DUMMY_TYPE_DEFINITIONS)
       in 'import'
-        process_import
+        process_import.call(DUMMY_TYPE_DEFINITIONS)
       in 'elem'
         process_element_segment
       in 'data'
@@ -419,9 +419,11 @@ module Wasminna
       read => name
       descriptor = read_list { process_import_descriptor.call(DUMMY_TYPE_DEFINITIONS) }
 
-      [
-        ['import', module_name, name, descriptor]
-      ]
+      after_all_fields do
+        [
+          ['import', module_name, name, descriptor]
+        ]
+      end
     end
 
     def process_import_descriptor

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -440,7 +440,7 @@ module Wasminna
       if can_read_list?
         process_active_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       elsif peek in 'declare'
-        process_declarative_element_segment(id:)
+        process_declarative_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
         process_passive_element_segment(id:)
       end
@@ -469,9 +469,11 @@ module Wasminna
       read => 'declare'
       element_list = process_element_list(func_optional: false).call(DUMMY_TYPE_DEFINITIONS)
 
-      [
-        ['elem', *id, 'declare', *element_list]
-      ]
+      after_all_fields do
+        [
+          ['elem', *id, 'declare', *element_list]
+        ]
+      end
     end
 
     def process_passive_element_segment(id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -438,7 +438,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_list?
-        process_active_element_segment(id:)
+        process_active_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       elsif peek in 'declare'
         process_declarative_element_segment(id:)
       else
@@ -458,9 +458,11 @@ module Wasminna
         table_use = %w[table 0]
       end
 
-      [
-        ['elem', *id, table_use, offset, *element_list]
-      ]
+      after_all_fields do
+        [
+          ['elem', *id, table_use, offset, *element_list]
+        ]
+      end
     end
 
     def process_declarative_element_segment(id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -101,7 +101,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'func', id:)
+        expand_inline_import_export(kind: 'func', id:).call(DUMMY_TYPE_DEFINITIONS)
       else
         typeuse = process_typeuse.call(DUMMY_TYPE_DEFINITIONS)
         locals = process_locals
@@ -118,7 +118,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'table', id:)
+        expand_inline_import_export(kind: 'table', id:).call(DUMMY_TYPE_DEFINITIONS)
       elsif can_read_inline_element_segment?
         expand_inline_element_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
@@ -170,7 +170,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'memory', id:)
+        expand_inline_import_export(kind: 'memory', id:).call(DUMMY_TYPE_DEFINITIONS)
       elsif can_read_inline_data_segment?
         expand_inline_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS)
       else
@@ -212,7 +212,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'global', id:)
+        expand_inline_import_export(kind: 'global', id:).call(DUMMY_TYPE_DEFINITIONS)
       else
         read => type
         instructions = process_instructions.call(DUMMY_TYPE_DEFINITIONS)
@@ -230,9 +230,9 @@ module Wasminna
     def expand_inline_import_export(**)
       case peek
       in ['import', _, _]
-        expand_inline_import(**).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_import(**)
       in ['export', _]
-        expand_inline_export(**).call(DUMMY_TYPE_DEFINITIONS)
+        expand_inline_export(**)
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -101,19 +101,15 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'func', id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
-          after_all_fields do
-            result
-          end
-        end
+        expand_inline_import_export(kind: 'func', id:)
       else
-        typeuse = process_typeuse.call(DUMMY_TYPE_DEFINITIONS)
+        typeuse = process_typeuse
         locals = process_locals
-        body = process_instructions.call(DUMMY_TYPE_DEFINITIONS)
+        body = process_instructions
 
-        after_all_fields do
+        after_all_fields do |type_definitions|
           [
-            ['func', *id, *typeuse, *locals, *body]
+            ['func', *id, *typeuse.call(type_definitions), *locals, *body.call(type_definitions)]
           ]
         end
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -477,11 +477,11 @@ module Wasminna
     end
 
     def process_passive_element_segment(id:)
-      element_list = process_element_list(func_optional: false).call(DUMMY_TYPE_DEFINITIONS)
+      element_list = process_element_list(func_optional: false)
 
-      after_all_fields do
+      after_all_fields do |type_definitions|
         [
-          ['elem', *id, *element_list]
+          ['elem', *id, *element_list.call(type_definitions)]
         ]
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -438,7 +438,7 @@ module Wasminna
           read
         end
       offset = read_list { process_offset.call(DUMMY_TYPE_DEFINITIONS) }
-      element_list = process_element_list(func_optional: table_use.nil?)
+      element_list = process_element_list(func_optional: table_use.nil?).call(DUMMY_TYPE_DEFINITIONS)
 
       if table_use.nil?
         table_use = %w[table 0]
@@ -451,7 +451,7 @@ module Wasminna
 
     def process_declarative_element_segment(id:)
       read => 'declare'
-      element_list = process_element_list(func_optional: false)
+      element_list = process_element_list(func_optional: false).call(DUMMY_TYPE_DEFINITIONS)
 
       [
         ['elem', *id, 'declare', *element_list]
@@ -459,7 +459,7 @@ module Wasminna
     end
 
     def process_passive_element_segment(id:)
-      element_list = process_element_list(func_optional: false)
+      element_list = process_element_list(func_optional: false).call(DUMMY_TYPE_DEFINITIONS)
 
       [
         ['elem', *id, *element_list]
@@ -485,7 +485,9 @@ module Wasminna
         read => 'funcref' | 'externref' => reftype
         items = process_element_expressions.call(DUMMY_TYPE_DEFINITIONS)
 
-        [reftype, *items]
+        after_all_fields do
+          [reftype, *items]
+        end
       else
         if !func_optional || (peek in 'func')
           read => 'func'
@@ -495,7 +497,9 @@ module Wasminna
             process_element_expressions.call(DUMMY_TYPE_DEFINITIONS)
           end
 
-        ['funcref', *items]
+        after_all_fields do
+          ['funcref', *items]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -105,7 +105,7 @@ module Wasminna
       else
         typeuse = process_typeuse.call(DUMMY_TYPE_DEFINITIONS)
         locals = process_locals
-        body = process_instructions
+        body = process_instructions.call(DUMMY_TYPE_DEFINITIONS)
 
         [
           ['func', *id, *typeuse, *locals, *body]
@@ -207,7 +207,7 @@ module Wasminna
         expand_inline_import_export(kind: 'global', id:)
       else
         read => type
-        instructions = process_instructions
+        instructions = process_instructions.call(DUMMY_TYPE_DEFINITIONS)
 
         [
           ['global', *id, type, *instructions]
@@ -321,11 +321,15 @@ module Wasminna
 
           ['select', *results]
         in [*]
-          read_list { [process_instructions] }
+          read_list { [process_instructions.call(DUMMY_TYPE_DEFINITIONS)] }
         else
           [read]
         end
-      end.flatten(1)
+      end.flatten(1).then do |result|
+        after_all_fields do
+          result
+        end
+      end
     end
 
     def process_blocktype
@@ -348,7 +352,7 @@ module Wasminna
     end
 
     def process_instruction
-      process_instructions # TODO only process one instruction
+      process_instructions.call(DUMMY_TYPE_DEFINITIONS) # TODO only process one instruction
     end
 
     def process_type_definition
@@ -444,7 +448,7 @@ module Wasminna
       instructions =
         if peek in 'offset'
           read => 'offset'
-          process_instructions
+          process_instructions.call(DUMMY_TYPE_DEFINITIONS)
         else
           process_instruction
         end
@@ -481,7 +485,7 @@ module Wasminna
       instructions =
         if peek in 'item'
           read => 'item'
-          process_instructions
+          process_instructions.call(DUMMY_TYPE_DEFINITIONS)
         else
           process_instruction
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -491,7 +491,7 @@ module Wasminna
 
     def process_element_expressions
       repeatedly do
-        read_list { process_element_expression }
+        read_list { process_element_expression.call(DUMMY_TYPE_DEFINITIONS) }
       end
     end
 
@@ -504,7 +504,9 @@ module Wasminna
           process_instruction.call(DUMMY_TYPE_DEFINITIONS)
         end
 
-      ['item', *instructions]
+      after_all_fields do
+        ['item', *instructions]
+      end
     end
 
     def process_function_indexes

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -174,17 +174,9 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'memory', id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
-          after_all_fields do
-            result
-          end
-        end
+        expand_inline_import_export(kind: 'memory', id:)
       elsif can_read_inline_data_segment?
-        expand_inline_data_segment(id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
-          after_all_fields do
-            result
-          end
-        end
+        expand_inline_data_segment(id:)
       else
         rest = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -218,18 +218,14 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'global', id:).call(DUMMY_TYPE_DEFINITIONS).then do |result|
-          after_all_fields do
-            result
-          end
-        end
+        expand_inline_import_export(kind: 'global', id:)
       else
         read => type
-        instructions = process_instructions.call(DUMMY_TYPE_DEFINITIONS)
+        instructions = process_instructions
 
-        after_all_fields do
+        after_all_fields do |type_definitions|
           [
-            ['global', *id, type, *instructions]
+            ['global', *id, type, *instructions.call(type_definitions)]
           ]
         end
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -92,7 +92,7 @@ module Wasminna
       in 'data'
         process_data_segment.call(DUMMY_TYPE_DEFINITIONS)
       in 'export' | 'start'
-        process_unabbreviated_field
+        process_unabbreviated_field.call(DUMMY_TYPE_DEFINITIONS)
       end
     end
 
@@ -607,9 +607,11 @@ module Wasminna
       read => 'export' | 'start' => kind
       rest = repeatedly { read }
 
-      [
-        [kind, *rest]
-      ]
+      after_all_fields do
+        [
+          [kind, *rest]
+        ]
+      end
     end
 
     def process_assert_trap

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -69,30 +69,30 @@ module Wasminna
 
     def process_fields
       repeatedly do
-        read_list { process_field }
+        read_list { process_field.call(DUMMY_TYPE_DEFINITIONS) }
       end.flatten(1)
     end
 
     def process_field
       case peek
       in 'func'
-        process_function_definition.call(DUMMY_TYPE_DEFINITIONS)
+        process_function_definition
       in 'table'
-        process_table_definition.call(DUMMY_TYPE_DEFINITIONS)
+        process_table_definition
       in 'memory'
-        process_memory_definition.call(DUMMY_TYPE_DEFINITIONS)
+        process_memory_definition
       in 'global'
-        process_global_definition.call(DUMMY_TYPE_DEFINITIONS)
+        process_global_definition
       in 'type'
-        process_type_definition.call(DUMMY_TYPE_DEFINITIONS)
+        process_type_definition
       in 'import'
-        process_import.call(DUMMY_TYPE_DEFINITIONS)
+        process_import
       in 'elem'
-        process_element_segment.call(DUMMY_TYPE_DEFINITIONS)
+        process_element_segment
       in 'data'
-        process_data_segment.call(DUMMY_TYPE_DEFINITIONS)
+        process_data_segment
       in 'export' | 'start'
-        process_unabbreviated_field.call(DUMMY_TYPE_DEFINITIONS)
+        process_unabbreviated_field
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -166,11 +166,7 @@ module Wasminna
           ['elem', ['table', id], %w[i32.const 0], item_type, *items]
         ]
 
-      read_list(from: expanded) { process_fields.call(DUMMY_TYPE_DEFINITIONS) }.then do |result|
-        after_all_fields do
-          result
-        end
-      end
+      read_list(from: expanded) { process_fields }
     end
 
     def process_memory_definition


### PR DESCRIPTION
To desugar the [type use abbreviation](https://webassembly.github.io/spec/core/text/modules.html#abbreviations) we’ll need access to a list of all the module’s [type definitions](https://webassembly.github.io/spec/core/text/modules.html#types) when preprocessing a [type use](https://webassembly.github.io/spec/core/text/modules.html#type-uses), but the full list of type definitions will only be available once the complete module has been processed. This creates a chicken-and-egg situation: we can’t desugar a type use until we’ve processed all of the enclosing module’s fields, but many of those fields will contain type uses which need to be desugared during processing.

This PR breaks the deadlock by refactoring the preprocessor to allow some field-processing methods to return a “deferred result”, namely a proc which must be called with a list of type definitions in order to produce the final S-expression. Deferred results give us the ability to process a module’s fields first and then provide type definitions later; the next step will be to generate the type definitions during processing so we can make use of that ability.

This continues the preparatory work from #12 and #13. We’re still in the “[make the change easy](https://twitter.com/KentBeck/status/250733358307500032)” phase, so there’s no externally visible difference in the preprocessor’s behaviour yet.