### PR TITLE
Allow type definitions to be generated while preprocessing a module

### DIFF
--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -105,7 +105,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'func', id:)
+        expand_inline_import_export(kind: 'func', id:).first
       else
         typeuse = process_typeuse
         locals = process_locals
@@ -124,7 +124,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'table', id:)
+        expand_inline_import_export(kind: 'table', id:).first
       elsif can_read_inline_element_segment?
         expand_inline_element_segment(id:)
       else
@@ -174,7 +174,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'memory', id:)
+        expand_inline_import_export(kind: 'memory', id:).first
       elsif can_read_inline_data_segment?
         expand_inline_data_segment(id:)
       else
@@ -214,7 +214,7 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'global', id:)
+        expand_inline_import_export(kind: 'global', id:).first
       else
         read => type
         instructions = process_instructions
@@ -234,9 +234,9 @@ module Wasminna
     def expand_inline_import_export(**)
       case peek
       in ['import', _, _]
-        expand_inline_import(**).first
+        expand_inline_import(**)
       in ['export', _]
-        expand_inline_export(**).first
+        expand_inline_export(**)
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -69,7 +69,7 @@ module Wasminna
 
     def process_fields
       repeatedly do
-        read_list { process_field }
+        read_list { process_field.first }
       end.then do |fields|
         after_all_fields do |type_definitions|
           fields.flat_map { |field| field.call(type_definitions) }
@@ -80,23 +80,23 @@ module Wasminna
     def process_field
       case peek
       in 'func'
-        process_function_definition.first
+        process_function_definition
       in 'table'
-        process_table_definition.first
+        process_table_definition
       in 'memory'
-        process_memory_definition.first
+        process_memory_definition
       in 'global'
-        process_global_definition.first
+        process_global_definition
       in 'type'
-        process_type_definition.first
+        process_type_definition
       in 'import'
-        process_import.first
+        process_import
       in 'elem'
-        process_element_segment.first
+        process_element_segment
       in 'data'
-        process_data_segment.first
+        process_data_segment
       in 'export' | 'start'
-        process_unabbreviated_field.first
+        process_unabbreviated_field
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -234,7 +234,7 @@ module Wasminna
     def expand_inline_import_export(**)
       case peek
       in ['import', _, _]
-        expand_inline_import(**)
+        expand_inline_import(**).first
       in ['export', _]
         expand_inline_export(**)
       end
@@ -249,7 +249,10 @@ module Wasminna
           ['import', module_name, name, [kind, *id, *description]]
         ]
 
-      read_list(from: expanded) { process_fields }
+      [
+        read_list(from: expanded) { process_fields },
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def expand_inline_export(kind:, id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -236,7 +236,7 @@ module Wasminna
       in ['import', _, _]
         expand_inline_import(**).first
       in ['export', _]
-        expand_inline_export(**)
+        expand_inline_export(**).first
       end
     end
 
@@ -268,7 +268,10 @@ module Wasminna
           [kind, id, *description]
         ]
 
-      read_list(from: expanded) { process_fields }
+      [
+        read_list(from: expanded) { process_fields },
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -179,7 +179,7 @@ module Wasminna
       if can_read_inline_import_export?
         expand_inline_import_export(kind: 'memory', id:).first
       elsif can_read_inline_data_segment?
-        expand_inline_data_segment(id:)
+        expand_inline_data_segment(id:).first
       else
         rest = repeatedly { read }
 
@@ -209,7 +209,10 @@ module Wasminna
           ['data', ['memory', id], %w[i32.const 0], *strings]
         ]
 
-      read_list(from: expanded) { process_fields }
+      [
+        read_list(from: expanded) { process_fields },
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_global_definition

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -84,7 +84,7 @@ module Wasminna
       in 'table'
         process_table_definition.first
       in 'memory'
-        process_memory_definition
+        process_memory_definition.first
       in 'global'
         process_global_definition
       in 'type'
@@ -183,17 +183,20 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'memory', id:).first
+        expand_inline_import_export(kind: 'memory', id:)
       elsif can_read_inline_data_segment?
-        expand_inline_data_segment(id:).first
+        expand_inline_data_segment(id:)
       else
         rest = repeatedly { read }
 
-        after_all_fields do
-          [
-            ['memory', *id, *rest]
-          ]
-        end
+        [
+          after_all_fields do
+            [
+              ['memory', *id, *rest]
+            ]
+          end,
+          DUMMY_TYPE_DEFINITIONS
+        ]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -82,7 +82,7 @@ module Wasminna
       in 'func'
         process_function_definition.first
       in 'table'
-        process_table_definition
+        process_table_definition.first
       in 'memory'
         process_memory_definition
       in 'global'
@@ -127,17 +127,20 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'table', id:).first
+        expand_inline_import_export(kind: 'table', id:)
       elsif can_read_inline_element_segment?
-        expand_inline_element_segment(id:).first
+        expand_inline_element_segment(id:)
       else
         rest = repeatedly { read }
 
-        after_all_fields do
-          [
-            ['table', *id, *rest]
-          ]
-        end
+        [
+          after_all_fields do
+            [
+              ['table', *id, *rest]
+            ]
+          end,
+          DUMMY_TYPE_DEFINITIONS
+        ]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -69,8 +69,8 @@ module Wasminna
 
     def process_fields
       repeatedly do
-        read_list { process_field.first }
-      end.then do |fields|
+        read_list { process_field }
+      end.transpose.then do |fields = [], _|
         after_all_fields do |type_definitions|
           fields.flat_map { |field| field.call(type_definitions) }
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -86,7 +86,7 @@ module Wasminna
       in 'memory'
         process_memory_definition.first
       in 'global'
-        process_global_definition
+        process_global_definition.first
       in 'type'
         process_type_definition.first
       in 'import'
@@ -229,16 +229,19 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'global', id:).first
+        expand_inline_import_export(kind: 'global', id:)
       else
         read => type
         instructions = process_instructions
 
-        after_all_fields do |type_definitions|
-          [
-            ['global', *id, type, *instructions.call(type_definitions)]
-          ]
-        end
+        [
+          after_all_fields do |type_definitions|
+            [
+              ['global', *id, type, *instructions.call(type_definitions)]
+            ]
+          end,
+          DUMMY_TYPE_DEFINITIONS
+        ]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -92,7 +92,7 @@ module Wasminna
       in 'import'
         process_import.first
       in 'elem'
-        process_element_segment
+        process_element_segment.first
       in 'data'
         process_data_segment
       in 'export' | 'start'
@@ -467,13 +467,16 @@ module Wasminna
       read => 'elem'
       read_optional_id => id
 
-      if can_read_list?
-        process_active_element_segment(id:)
-      elsif peek in 'declare'
-        process_declarative_element_segment(id:)
-      else
-        process_passive_element_segment(id:)
-      end
+      [
+        if can_read_list?
+          process_active_element_segment(id:)
+        elsif peek in 'declare'
+          process_declarative_element_segment(id:)
+        else
+          process_passive_element_segment(id:)
+        end,
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_active_element_segment(id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -88,7 +88,7 @@ module Wasminna
       in 'global'
         process_global_definition
       in 'type'
-        process_type_definition
+        process_type_definition.first
       in 'import'
         process_import
       in 'elem'
@@ -386,11 +386,14 @@ module Wasminna
       read_optional_id => id
       functype = read_list { process_functype }
 
-      after_all_fields do
-        [
-          ['type', *id, functype]
-        ]
-      end
+      [
+        after_all_fields do
+          [
+            ['type', *id, functype]
+          ]
+        end,
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_functype

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -90,7 +90,7 @@ module Wasminna
       in 'type'
         process_type_definition.first
       in 'import'
-        process_import
+        process_import.first
       in 'elem'
         process_element_segment
       in 'data'
@@ -434,11 +434,14 @@ module Wasminna
       read => name
       descriptor = read_list { process_import_descriptor }
 
-      after_all_fields do |type_definitions|
-        [
-          ['import', module_name, name, descriptor.call(type_definitions)]
-        ]
-      end
+      [
+        after_all_fields do |type_definitions|
+          [
+            ['import', module_name, name, descriptor.call(type_definitions)]
+          ]
+        end,
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_import_descriptor

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -126,7 +126,7 @@ module Wasminna
       if can_read_inline_import_export?
         expand_inline_import_export(kind: 'table', id:).first
       elsif can_read_inline_element_segment?
-        expand_inline_element_segment(id:)
+        expand_inline_element_segment(id:).first
       else
         rest = repeatedly { read }
 
@@ -166,7 +166,10 @@ module Wasminna
           ['elem', ['table', id], %w[i32.const 0], item_type, *items]
         ]
 
-      read_list(from: expanded) { process_fields }
+      [
+        read_list(from: expanded) { process_fields },
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_memory_definition

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -80,7 +80,7 @@ module Wasminna
     def process_field
       case peek
       in 'func'
-        process_function_definition
+        process_function_definition.first
       in 'table'
         process_table_definition
       in 'memory'
@@ -105,17 +105,20 @@ module Wasminna
       read_optional_id => id
 
       if can_read_inline_import_export?
-        expand_inline_import_export(kind: 'func', id:).first
+        expand_inline_import_export(kind: 'func', id:)
       else
         typeuse = process_typeuse
         locals = process_locals
         body = process_instructions
 
-        after_all_fields do |type_definitions|
-          [
-            ['func', *id, *typeuse.call(type_definitions), *locals, *body.call(type_definitions)]
-          ]
-        end
+        [
+          after_all_fields do |type_definitions|
+            [
+              ['func', *id, *typeuse.call(type_definitions), *locals, *body.call(type_definitions)]
+            ]
+          end,
+          DUMMY_TYPE_DEFINITIONS
+        ]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -94,7 +94,7 @@ module Wasminna
       in 'elem'
         process_element_segment.first
       in 'data'
-        process_data_segment
+        process_data_segment.first
       in 'export' | 'start'
         process_unabbreviated_field
       end
@@ -590,11 +590,14 @@ module Wasminna
       read => 'data'
       read_optional_id => id
 
-      if can_read_list?
-        process_active_data_segment(id:)
-      else
-        process_passive_data_segment(id:)
-      end
+      [
+        if can_read_list?
+          process_active_data_segment(id:)
+        else
+          process_passive_data_segment(id:)
+        end,
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_active_data_segment(id:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -62,8 +62,8 @@ module Wasminna
         strings = repeatedly { read }
         ['module', *id, 'binary', *strings]
       else
-        fields = process_fields.first.call(DUMMY_TYPE_DEFINITIONS)
-        ['module', *id, *fields]
+        fields, type_definitions = process_fields
+        ['module', *id, *fields.call(type_definitions)]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -96,7 +96,7 @@ module Wasminna
       in 'data'
         process_data_segment.first
       in 'export' | 'start'
-        process_unabbreviated_field
+        process_unabbreviated_field.first
       end
     end
 
@@ -631,11 +631,14 @@ module Wasminna
       read => 'export' | 'start' => kind
       rest = repeatedly { read }
 
-      after_all_fields do
-        [
-          [kind, *rest]
-        ]
-      end
+      [
+        after_all_fields do
+          [
+            [kind, *rest]
+          ]
+        end,
+        DUMMY_TYPE_DEFINITIONS
+      ]
     end
 
     def process_assert_trap


### PR DESCRIPTION
The #process_module method is ready to provide type definitions to the deferred results produced by preprocessing the module’s fields so that the [type use abbreviation](https://webassembly.github.io/spec/core/text/modules.html#abbreviations) can be desugared, but we don’t currently have any way to communicate those type definitions to #process_module. Although the processed fields do include type definition fields, they’re all deferred until we’re ready to provide the type definitions — another chicken-and-egg situation.

This PR adds a “list of type definitions” return value to #process_type_definition and refactors other preprocessor methods to allow that value to propagate up to #process_module. The next (and final!) step will be to populate it with real type definitions and use those to desugar the type use abbreviation.

This concludes the preparatory work begun in #12, #13 and #14, and therefore still doesn’t introduce any externally visible changes to the preprocessor’s behaviour.