### PR TITLE
Desugar type use abbreviation

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -334,21 +334,11 @@ module Wasminna
     end
 
     def parse_typeuse
-      if can_read_list?(starting_with: 'type')
-        index = read_list(starting_with: 'type') { parse_index(context.types) }
-      end
+      index = read_list(starting_with: 'type') { parse_index(context.types) }
       parameter_names, parameters = parse_parameters
       results = parse_results
 
-      if index.nil?
-        generated_type = Type.new(parameters:, results:)
-        index = context.typedefs.find_index(generated_type)
-
-        if index.nil?
-          index = context.typedefs.length
-          self.context = context + Context.new(typedefs: [generated_type])
-        end
-      elsif [parameters, results].all?(&:empty?)
+      if [parameters, results].all?(&:empty?)
         context.typedefs.slice(index) => { parameters: }
         parameter_names = parameters.map { nil }
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -20,7 +20,7 @@ module Wasminna
 
     private
 
-    attr_accessor :s_expression, :context
+    attr_accessor :s_expression
 
     def parse_commands
       repeatedly { parse_command }
@@ -530,14 +530,6 @@ module Wasminna
           [parse_instruction(context:)]
         end
       end.flatten(1)
-    end
-
-    def with_context(context)
-      previous_context, self.context = self.context, context
-
-      yield.tap do
-        self.context = previous_context
-      end
     end
 
     def parse_instruction(context:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -323,12 +323,10 @@ module Wasminna
       local_names, locals = parse_locals
       locals_context = Context.new(locals: parameter_names + local_names)
       raise unless locals_context.well_formed?
-      body, updated_typedefs =
+      body =
         with_context(context + locals_context) do
-          body = parse_instructions
-          [body, context.typedefs]
+          parse_instructions
         end
-      self.context = context.with(typedefs: updated_typedefs)
 
       Function.new(type_index:, locals:, body:)
     end
@@ -727,14 +725,8 @@ module Wasminna
 
     def parse_blocktype
       if can_read_list?(starting_with: 'type')
-        type_index, parameter_names, updated_typedefs =
-          with_context(context) do
-            parse_typeuse => [type_index, parameter_names]
-            [type_index, parameter_names, context.typedefs]
-          end
+        parse_typeuse => [type_index, parameter_names]
         raise unless parameter_names.all?(&:nil?)
-
-        self.context = context.with(typedefs: updated_typedefs)
         type_index
       else
         parse_results => [] | [_] => results

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -734,17 +734,8 @@ module Wasminna
           end
         raise unless parameter_names.all?(&:nil?)
 
-        type = updated_typedefs.slice(type_index)
-        if (
-          type.parameters.none? &&
-          (type.results.none? || type.results.one?) &&
-          context.typedefs.find_index(type).nil?
-        )
-          type.results
-        else
-          self.context = context.with(typedefs: updated_typedefs)
-          type_index
-        end
+        self.context = context.with(typedefs: updated_typedefs)
+        type_index
       else
         parse_results => [] | [_] => results
         results

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -400,14 +400,13 @@ module Wasminna
       read => 'type'
       read_optional_id => id
       functype = read_list { process_functype }
+      type_definition = ['type', *id, functype]
 
       [
         after_all_fields do
-          [
-            ['type', *id, functype]
-          ]
+          [type_definition]
         end,
-        DUMMY_TYPE_DEFINITIONS
+        [type_definition]
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -58,10 +58,26 @@ module Wasminna
       if peek in 'binary'
         read => 'binary'
         strings = repeatedly { read }
+
         ['module', *id, 'binary', *strings]
       else
         fields, type_definitions = process_fields
-        ['module', *id, *fields.call(type_definitions)]
+        original_type_definitions = type_definitions.length
+        fields = fields.call(type_definitions)
+        generated_type_definitions =
+          type_definitions.drop(original_type_definitions)
+        fields = fields + deep_copy(generated_type_definitions)
+
+        ['module', *id, *fields]
+      end
+    end
+
+    def deep_copy(s_expression)
+      case s_expression
+      in [*s_expressions]
+        s_expressions.map { deep_copy(_1) }
+      else
+        s_expression
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -311,8 +311,10 @@ module Wasminna
       functype => ['func', *parameters_and_results]
       parameters, results =
         parameters_and_results.partition { _1 in ['param', *] }
+      parameter_value_types = parameters.map(&:last)
+      result_value_types = results.map(&:last)
 
-      [parameters, results]
+      [parameter_value_types, result_value_types]
     end
 
     def process_parameters

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -293,9 +293,16 @@ module Wasminna
       else
         parameters = process_parameters
         results = process_results
+        functype = ['func', *parameters, *results]
 
-        after_all_fields do
-          [*parameters, *results]
+        after_all_fields do |type_definitions|
+          index = type_definitions.index { _1.last == functype }
+
+          if index.nil?
+            [*parameters, *results]
+          else
+            [['type', index.to_s], *parameters, *results]
+          end
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -120,7 +120,7 @@ module Wasminna
               ['func', *id, *typeuse.call(type_definitions), *locals, *body.call(type_definitions)]
             ]
           end,
-          DUMMY_TYPE_DEFINITIONS
+          []
         ]
       end
     end
@@ -142,7 +142,7 @@ module Wasminna
               ['table', *id, *rest]
             ]
           end,
-          DUMMY_TYPE_DEFINITIONS
+          []
         ]
       end
     end
@@ -195,7 +195,7 @@ module Wasminna
               ['memory', *id, *rest]
             ]
           end,
-          DUMMY_TYPE_DEFINITIONS
+          []
         ]
       end
     end
@@ -237,7 +237,7 @@ module Wasminna
               ['global', *id, type, *instructions.call(type_definitions)]
             ]
           end,
-          DUMMY_TYPE_DEFINITIONS
+          []
         ]
       end
     end
@@ -430,7 +430,7 @@ module Wasminna
             ['import', module_name, name, descriptor.call(type_definitions)]
           ]
         end,
-        DUMMY_TYPE_DEFINITIONS
+        []
       ]
     end
 
@@ -465,7 +465,7 @@ module Wasminna
         else
           process_passive_element_segment(id:)
         end,
-        DUMMY_TYPE_DEFINITIONS
+        []
       ]
     end
 
@@ -586,7 +586,7 @@ module Wasminna
         else
           process_passive_data_segment(id:)
         end,
-        DUMMY_TYPE_DEFINITIONS
+        []
       ]
     end
 
@@ -627,7 +627,7 @@ module Wasminna
             [kind, *rest]
           ]
         end,
-        DUMMY_TYPE_DEFINITIONS
+        []
       ]
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -283,13 +283,20 @@ module Wasminna
 
     def process_typeuse
       if can_read_list?(starting_with: 'type')
-        type = [read]
-      end
-      parameters = process_parameters
-      results = process_results
+        read => type
+        parameters = process_parameters
+        results = process_results
 
-      after_all_fields do
-        [*type, *parameters, *results]
+        after_all_fields do
+          [type, *parameters, *results]
+        end
+      else
+        parameters = process_parameters
+        results = process_results
+
+        after_all_fields do
+          [*parameters, *results]
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -293,10 +293,10 @@ module Wasminna
       else
         parameters = process_parameters
         results = process_results
-        functype = ['func', *parameters, *results]
+        type = function_type(['func', *parameters, *results])
 
         after_all_fields do |type_definitions|
-          index = type_definitions.index { _1.last == functype }
+          index = type_definitions.index { function_type(_1.last) == type }
 
           if index.nil?
             [*parameters, *results]
@@ -305,6 +305,14 @@ module Wasminna
           end
         end
       end
+    end
+
+    def function_type(functype)
+      functype => ['func', *parameters_and_results]
+      parameters, results =
+        parameters_and_results.partition { _1 in ['param', *] }
+
+      [parameters, results]
     end
 
     def process_parameters

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -51,8 +51,6 @@ module Wasminna
       end
     end
 
-    DUMMY_TYPE_DEFINITIONS = []
-
     def process_module
       read => 'module'
       read_optional_id => id

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -299,10 +299,11 @@ module Wasminna
           index = type_definitions.index { function_type(_1.last) == type }
 
           if index.nil?
-            [*parameters, *results]
-          else
-            [['type', index.to_s], *parameters, *results]
+            index = type_definitions.length
+            type_definitions << ['type', ['func', *parameters, *results]]
           end
+
+          [['type', index.to_s], *parameters, *results]
         end
       end
     end

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -705,6 +705,42 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type (func (param i32) (result f32)))
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param $x i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param i32) (result i64)))
+--
+  (func (type 0) (param $x i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param i32) (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param $x i32) (result i64)))
+--
+  (func (type 0) (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param $x i32) (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param $x i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param $y i32) (result i64)))
+--
+  (func (type 0) (param $x i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param $y i32) (result i64)))
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -741,6 +741,41 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type (func (param $y i32) (result i64)))
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param i32) (result i64)
+    (i64.const 1)
+  )
+--
+  (func (type 0) (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param i32) (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param i32) (result i64)
+    (i64.const 1)
+  )
+  (func (param i64) (result i32)
+    (i32.const 2)
+  )
+  (func (param i32) (result i64)
+    (i64.const 3)
+  )
+--
+  (func (type 0) (param i32) (result i64)
+    (i64.const 1)
+  )
+  (func (type 1) (param i64) (result i32)
+    (i32.const 2)
+  )
+  (func (type 0) (param i32) (result i64)
+    (i64.const 3)
+  )
+  (type (func (param i32) (result i64)))
+  (type (func (param i64) (result i32)))
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -535,6 +535,176 @@ assert_preprocess_module_fields <<'--', <<'--'
   )
 --
 
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param i32) (result i64)))
+--
+  (func (type 0) (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param i32) (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param f32) (result f64)))
+  (type (func (param i32) (result i64)))
+--
+  (func (type 1) (param i32) (result i64)
+    (i64.const 1)
+  )
+  (type (func (param f32) (result f64)))
+  (type (func (param i32) (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func (import "a" "b") (param i32))
+  (type (func (param i32)))
+--
+  (import "a" "b" (func (type 0) (param i32)))
+  (type (func (param i32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (import "a" "b" (func (param i32)))
+  (type (func (param i32)))
+--
+  (import "a" "b" (func (type 0) (param i32)))
+  (type (func (param i32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (func
+    (export "a")
+    (export "b")
+    (import "c" "d")
+    (param i32)
+  )
+  (type (func (param i32)))
+--
+  (export "a" (func $__fresh_0))
+  (export "b" (func $__fresh_0))
+  (import "c" "d" (func $__fresh_0 (type 0) (param i32)))
+  (type (func (param i32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (global $g i32
+    (call_indirect (param i32) (result f32))
+  )
+  (type (func (param i32) (result f32)))
+--
+  (global $g i32
+    (call_indirect (type 0) (param i32) (result f32))
+  )
+  (type (func (param i32) (result f32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table $t)
+    (offset
+      (call_indirect (param i32) (result f32))
+    )
+    funcref (item ref.func $f)
+  )
+  (type (func (param i32) (result f32)))
+--
+  (elem (table $t)
+    (offset
+      (call_indirect (type 0) (param i32) (result f32))
+    )
+    funcref (item ref.func $f)
+  )
+  (type (func (param i32) (result f32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (data (memory $m)
+    (offset
+      (call_indirect (param i32) (result f32))
+    )
+    "hello" "world"
+  )
+  (type (func (param i32) (result f32)))
+--
+  (data (memory $m)
+    (offset
+      (call_indirect (type 0) (param i32) (result f32))
+    )
+    "hello" "world"
+  )
+  (type (func (param i32) (result f32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    (block (param i32 i64)
+      (drop)
+      (drop)
+    )
+  )
+  (type (func (param i32) (param i64)))
+--
+  (type $t (func))
+  (func (type $t)
+    (block (type 1) (param i32) (param i64)
+      (drop)
+      (drop)
+    )
+  )
+  (type (func (param i32) (param i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    (block (param i32) (result i64)
+      (drop)
+      (i64.const 1)
+    )
+  )
+  (type (func (param i32) (result i64)))
+--
+  (type $t (func))
+  (func (type $t)
+    (block (type 1) (param i32) (result i64)
+      (drop)
+      (i64.const 1)
+    )
+  )
+  (type (func (param i32) (result i64)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (elem (table $t) (offset i32.const 0) funcref
+    (item (call_indirect (param i32) (result f32)))
+  )
+  (type (func (param i32) (result f32)))
+--
+  (elem (table $t) (offset i32.const 0) funcref
+    (item (call_indirect (type 0) (param i32) (result f32)))
+  )
+  (type (func (param i32) (result f32)))
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (table $t funcref
+    (elem (item (call_indirect (param i32) (result f32))))
+  )
+  (type (func (param i32) (result f32)))
+--
+  (table $t 1 1 funcref)
+  (elem (table $t) (offset i32.const 0) funcref
+    (item (call_indirect (type 0) (param i32) (result f32)))
+  )
+  (type (func (param i32) (result f32)))
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
As an [abbreviation](https://webassembly.github.io/spec/core/text/modules.html#abbreviations), a [type use](https://webassembly.github.io/spec/core/text/modules.html#type-uses) can be replaced by inline parameter and result declarations: instead of writing e.g. `(func (type $t) …)` and defining `$t` elsewhere in the module with `(type $t (func (param i32) (result i64)))`, we can write the more concise and expressive `(func (param i32) (result i64) …)`.

To support this abbreviation, a WebAssembly implementation must automatically insert a type index referring either to a matching type definition in the current module (e.g. `$t` above) or a newly-inserted type definition if no matching one exists.

This PR implements desugaring for this abbreviation in the preprocessor and removes support for it from the AST parser. It relies upon machinery introduced in #14 and #15 which allows type definitions to be collected while preprocessing a module’s fields and then provided to the deferred result to yield the final S-expressions.