### PR TITLE
Tidy up preprocessor, parser and interpreter for instruction abbreviations

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -738,25 +738,6 @@ module Wasminna
       parse_instructions(context:)
     end
 
-    def read_labelled(atom = nil, label: nil)
-      if atom.nil?
-        read => atom
-      else
-        read => ^atom
-      end
-
-      read_optional_id => id
-      unless id.nil?
-        if label.nil?
-          id => label
-        else
-          id => ^label
-        end
-      end
-
-      [atom, label]
-    end
-
     def parse_normal_instruction(context:)
       case read
       in 'return' | 'nop' | 'drop' | 'unreachable' | 'memory.grow' | 'memory.size' | 'memory.fill' | 'memory.copy' => keyword

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -852,9 +852,8 @@ module Wasminna
       kwargs => { until: terminator }
 
       repeatedly do
+        raise StopIteration if peek in ^terminator
         case peek
-        in ^terminator
-          raise StopIteration
         in 'block' | 'loop' | 'if'
           [read, *read_instructions(until: 'end'), read]
         else

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -558,7 +558,8 @@ module Wasminna
     end
 
     def parse_folded_structured_instruction(context:)
-      read_labelled => [keyword, label]
+      read => keyword
+      read_optional_id => label
       type = parse_blocktype(context:)
       context = Context.new(labels: [label]) + context
 
@@ -687,7 +688,8 @@ module Wasminna
     end
 
     def parse_structured_instruction(context:)
-      read_labelled => [keyword, label]
+      read => keyword
+      read_optional_id => label
       type = parse_blocktype(context:)
       context = Context.new(labels: [label]) + context
 
@@ -701,13 +703,17 @@ module Wasminna
           Loop.new(type:, body:)
         in 'if'
           consequent = parse_consequent(context:)
-          read_labelled('else', label:) if peek in 'else'
+          if peek in 'else'
+            read => 'else'
+            read_optional_id => nil | ^label
+          end
           alternative = parse_alternative(context:)
 
           If.new(type:, consequent:, alternative:)
         end
       end.tap do
-        read_labelled('end', label:)
+        read => 'end'
+        read_optional_id => nil | ^label
       end
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -693,7 +693,7 @@ module Wasminna
       type = parse_blocktype(context:)
       context = Context.new(labels: [label]) + context
 
-      read_list(from: read_instructions('end')) do
+      read_list(from: read_instructions(until: 'end')) do
         case keyword
         in 'block'
           body = parse_instructions(context:)
@@ -729,7 +729,7 @@ module Wasminna
     end
 
     def parse_consequent(context:)
-      read_list(from: read_instructions('else')) do
+      read_list(from: read_instructions(until: 'else')) do
         parse_instructions(context:)
       end
     end
@@ -856,13 +856,15 @@ module Wasminna
       end
     end
 
-    def read_instructions(terminator)
+    def read_instructions(**kwargs)
+      kwargs => { until: terminator }
+
       repeatedly do
         case peek
         in ^terminator
           raise StopIteration
         in 'block' | 'loop' | 'if'
-          [read, *read_instructions('end'), read]
+          [read, *read_instructions(until: 'end'), read]
         else
           [read]
         end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -853,13 +853,17 @@ module Wasminna
 
       repeatedly do
         raise StopIteration if peek in ^terminator
-        case peek
-        in 'block' | 'loop' | 'if'
-          [read, *read_instructions(until: 'end'), read]
-        else
-          [read]
-        end
+        read_instruction
       end.flatten(1)
+    end
+
+    def read_instruction
+      case peek
+      in 'block' | 'loop' | 'if'
+        [read, *read_instructions(until: 'end'), read]
+      else
+        [read]
+      end
     end
 
     def unsigned(signed, bits:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -702,12 +702,12 @@ module Wasminna
           body = parse_instructions(context:)
           Loop.new(type:, body:)
         in 'if'
-          consequent = parse_consequent(context:)
+          consequent = read_instructions(until: 'else') { parse_instructions(context:) }
           if peek in 'else'
             read => 'else'
             read_optional_id => nil | ^label
           end
-          alternative = parse_alternative(context:)
+          alternative = parse_instructions(context:)
 
           If.new(type:, consequent:, alternative:)
         end
@@ -726,16 +726,6 @@ module Wasminna
         parse_results => [] | [_] => results
         results
       end
-    end
-
-    def parse_consequent(context:)
-      read_instructions(until: 'else') do
-        parse_instructions(context:)
-      end
-    end
-
-    def parse_alternative(context:)
-      parse_instructions(context:)
     end
 
     def parse_normal_instruction(context:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -693,7 +693,7 @@ module Wasminna
       type = parse_blocktype(context:)
       context = Context.new(labels: [label]) + context
 
-      read_list(from: read_until('end')) do
+      read_list(from: read_instructions('end')) do
         case keyword
         in 'block'
           body = parse_instructions(context:)
@@ -729,7 +729,7 @@ module Wasminna
     end
 
     def parse_consequent(context:)
-      read_list(from: read_until('else')) do
+      read_list(from: read_instructions('else')) do
         parse_instructions(context:)
       end
     end
@@ -856,13 +856,13 @@ module Wasminna
       end
     end
 
-    def read_until(terminator)
+    def read_instructions(terminator)
       repeatedly do
         case peek
         in ^terminator
           raise StopIteration
         in 'block' | 'loop' | 'if'
-          [read, *read_until('end'), read]
+          [read, *read_instructions('end'), read]
         else
           [read]
         end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -184,7 +184,10 @@ module Wasminna
       read => 'invoke'
       read_optional_id => module_name
       parse_string => name
-      arguments = parse_instructions(context: Context.new)
+      arguments =
+        repeatedly do
+          read_list { parse_instruction(context: Context.new) }
+        end
 
       Invoke.new(module_name:, name:, arguments:)
     end
@@ -238,7 +241,7 @@ module Wasminna
           in 'f32.const' | 'f64.const'
             parse_float_expectation
           else
-            parse_instructions(context: Context.new)
+            parse_instruction(context: Context.new)
           end
         end
       end
@@ -253,7 +256,7 @@ module Wasminna
         NanExpectation.new(nan:, bits:)
       else
         number = parse_float(bits:)
-        [Const.new(type: :float, bits:, number:)]
+        Const.new(type: :float, bits:, number:)
       end
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -856,7 +856,9 @@ module Wasminna
       end
     end
 
-    def read_instructions(**kwargs)
+    def read_instructions(**kwargs, &)
+      return read_list(from: read_instructions(**kwargs), &) if block_given?
+
       kwargs => { until: terminator }
 
       repeatedly do

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -860,10 +860,18 @@ module Wasminna
     def read_instruction
       case peek
       in 'block' | 'loop' | 'if'
-        [read, *read_instructions(until: 'end'), read]
+        read_structured_instruction
       else
         [read]
       end
+    end
+
+    def read_structured_instruction
+      [
+        read,
+        *read_instructions(until: 'end'),
+        read
+      ]
     end
 
     def unsigned(signed, bits:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -693,7 +693,7 @@ module Wasminna
       type = parse_blocktype(context:)
       context = Context.new(labels: [label]) + context
 
-      read_list(from: read_instructions(until: 'end')) do
+      read_instructions(until: 'end') do
         case keyword
         in 'block'
           body = parse_instructions(context:)
@@ -729,7 +729,7 @@ module Wasminna
     end
 
     def parse_consequent(context:)
-      read_list(from: read_instructions(until: 'else')) do
+      read_instructions(until: 'else') do
         parse_instructions(context:)
       end
     end

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -21,6 +21,8 @@ module Wasminna
       private
 
       def read_list(from: read, starting_with: nil)
+        return read_list(from:, starting_with:) { repeatedly { read } } unless block_given?
+
         raise "not a list: #{from.inspect}" unless from in [*]
         previous_s_expression, self.s_expression = self.s_expression, from
 

--- a/lib/wasminna/interpreter.rb
+++ b/lib/wasminna/interpreter.rb
@@ -84,7 +84,7 @@ module Wasminna
                 float = Float.decode(actual_value, format:).to_f
                 success = float.nan? # TODO check whether canonical or arithmetic
               else
-                evaluate_expression(expected, locals: [])
+                evaluate_instruction(expected, locals: [])
                 stack.pop(1) => [expected_value]
                 raise unless stack.empty?
                 success = actual_value == expected_value

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -369,11 +369,11 @@ module Wasminna
         case peek
         in 'block' | 'loop' | 'if'
           read => 'block' | 'loop' | 'if' => keyword
-          read_optional_id => id
+          read_optional_id => label
           blocktype = process_blocktype
 
           after_all_fields do |type_definitions|
-            [keyword, *id, *blocktype.call(type_definitions)]
+            [keyword, *label, *blocktype.call(type_definitions)]
           end
         in 'call_indirect'
           read => 'call_indirect'

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -360,27 +360,8 @@ module Wasminna
           process_folded_instruction
         in 'block' | 'loop' | 'if'
           process_structured_instruction
-        in 'call_indirect'
-          read => 'call_indirect'
-          read_index => index if can_read_index?
-          typeuse = process_typeuse
-
-          after_all_fields do |type_definitions|
-            ['call_indirect', *index, *typeuse.call(type_definitions)]
-          end
-        in 'select'
-          read => 'select'
-          results = process_results
-
-          after_all_fields do
-            ['select', *results]
-          end
         else
-          read.then do |result|
-            after_all_fields do
-              [result]
-            end
-          end
+          process_plain_instruction
         end
       end.then do |results|
         after_all_fields do |type_definitions|
@@ -404,6 +385,32 @@ module Wasminna
 
       after_all_fields do |type_definitions|
         [keyword, *label, *blocktype.call(type_definitions)]
+      end
+    end
+
+    def process_plain_instruction
+      case peek
+      in 'call_indirect'
+        read => 'call_indirect'
+        read_index => index if can_read_index?
+        typeuse = process_typeuse
+
+        after_all_fields do |type_definitions|
+          ['call_indirect', *index, *typeuse.call(type_definitions)]
+        end
+      in 'select'
+        read => 'select'
+        results = process_results
+
+        after_all_fields do
+          ['select', *results]
+        end
+      else
+        read.then do |result|
+          after_all_fields do
+            [result]
+          end
+        end
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -212,7 +212,7 @@ module Wasminna
     end
 
     def expand_inline_data_segment(id:)
-      strings = read_list(starting_with: 'data') { repeatedly { read } }
+      strings = read_list(starting_with: 'data')
 
       id = fresh_id if id.nil?
       bytes = strings.sum { string_value(_1).bytesize }
@@ -288,7 +288,7 @@ module Wasminna
 
     def process_typeuse
       if can_read_list?(starting_with: 'type')
-        read => type
+        read_list => type
         parameters = process_parameters
         results = process_results
 
@@ -415,7 +415,7 @@ module Wasminna
     end
 
     def process_blocktype
-      type = [read] if can_read_list?(starting_with: 'type')
+      type = [read_list] if can_read_list?(starting_with: 'type')
       parameters = process_parameters
       results = process_results
       blocktype = [*type, *parameters, *results]
@@ -508,7 +508,7 @@ module Wasminna
     end
 
     def process_active_element_segment(id:)
-      table_use = read if can_read_list?(starting_with: 'table')
+      table_use = read_list if can_read_list?(starting_with: 'table')
       offset = read_list { process_offset }
       element_list = process_element_list(func_optional: table_use.nil?)
       table_use = %w[table 0] if table_use.nil?
@@ -621,7 +621,7 @@ module Wasminna
     def process_active_data_segment(id:)
       memory_use =
         if can_read_list?(starting_with: 'memory')
-          read
+          read_list
         else
           %w[memory 0]
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -368,12 +368,12 @@ module Wasminna
       repeatedly do
         case peek
         in 'block' | 'loop' | 'if'
-          read => 'block' | 'loop' | 'if' => kind
+          read => 'block' | 'loop' | 'if' => keyword
           read_optional_id => id
           blocktype = process_blocktype
 
           after_all_fields do |type_definitions|
-            [kind, *id, *blocktype.call(type_definitions)]
+            [keyword, *id, *blocktype.call(type_definitions)]
           end
         in 'call_indirect'
           read => 'call_indirect'

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -87,7 +87,7 @@ module Wasminna
       end.transpose.then do |fields = [], type_definitions = []|
         [
           after_all_fields do |type_definitions|
-            fields.flat_map { |field| field.call(type_definitions) }
+            fields.flat_map { _1.call(type_definitions) }
           end,
           type_definitions.flatten(1)
         ]
@@ -407,7 +407,7 @@ module Wasminna
         end
       end.then do |results|
         after_all_fields do |type_definitions|
-          results.flat_map { |result| result.call(type_definitions) }
+          results.flat_map { _1.call(type_definitions) }
         end
       end
     end
@@ -590,7 +590,7 @@ module Wasminna
         read_list { process_element_expression }
       end.then do |results|
         after_all_fields do |type_definitions|
-          results.map { |result| result.call(type_definitions) }
+          results.map { _1.call(type_definitions) }
         end
       end
     end
@@ -610,9 +610,7 @@ module Wasminna
     end
 
     def process_function_indexes
-      indexes = repeatedly { read }
-
-      indexes.map { |index| ['ref.func', index] }
+      repeatedly { read }.map { ['ref.func', _1] }
     end
 
     def process_data_segment

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -356,6 +356,8 @@ module Wasminna
     def process_instructions
       repeatedly do
         case peek
+        in [*]
+          process_folded_instruction
         in 'block' | 'loop' | 'if'
           process_structured_instruction
         in 'call_indirect'
@@ -373,8 +375,6 @@ module Wasminna
           after_all_fields do
             ['select', *results]
           end
-        in [*]
-          process_folded_instruction
         else
           read.then do |result|
             after_all_fields do

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -357,13 +357,7 @@ module Wasminna
       repeatedly do
         case peek
         in 'block' | 'loop' | 'if'
-          read => 'block' | 'loop' | 'if' => keyword
-          read_optional_id => label
-          blocktype = process_blocktype
-
-          after_all_fields do |type_definitions|
-            [keyword, *label, *blocktype.call(type_definitions)]
-          end
+          process_structured_instruction
         in 'call_indirect'
           read => 'call_indirect'
           read_index => index if can_read_index?
@@ -400,6 +394,16 @@ module Wasminna
         after_all_fields do |type_definitions|
           [result.call(type_definitions)]
         end
+      end
+    end
+
+    def process_structured_instruction
+      read => 'block' | 'loop' | 'if' => keyword
+      read_optional_id => label
+      blocktype = process_blocktype
+
+      after_all_fields do |type_definitions|
+        [keyword, *label, *blocktype.call(type_definitions)]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -380,11 +380,7 @@ module Wasminna
             ['select', *results]
           end
         in [*]
-          read_list { process_instructions }.then do |result|
-            after_all_fields do |type_definitions|
-              [result.call(type_definitions)]
-            end
-          end
+          process_folded_instruction
         else
           read.then do |result|
             after_all_fields do
@@ -395,6 +391,14 @@ module Wasminna
       end.then do |results|
         after_all_fields do |type_definitions|
           results.flat_map { _1.call(type_definitions) }
+        end
+      end
+    end
+
+    def process_folded_instruction
+      read_list { process_instructions }.then do |result|
+        after_all_fields do |type_definitions|
+          [result.call(type_definitions)]
         end
       end
     end

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -50,23 +50,41 @@ assert_preprocess_module_fields <<'--', <<'--'
 
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (result i32)))
-  (func (export "i32.test") (type $t) (return (i32.const 0x0bAdD00D)))
+  (func (export "i32.test") (type $t)
+    i32.const 0x0bAdD00D
+    return
+  )
 --
   (type $t (func (result i32)))
   (export "i32.test" (func $__fresh_0))
-  (func $__fresh_0 (type $t) (return (i32.const 0x0bAdD00D)))
+  (func $__fresh_0 (type $t)
+    i32.const 0x0bAdD00D
+    return
+  )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (result i32)))
-  (func (export "i32.test") (type $t) (return (i32.const 0x0bAdD00D)))
-  (func (export "i32.umax") (type $t) (return (i32.const 0xffffffff)))
+  (func (export "i32.test") (type $t)
+    i32.const 0x0bAdD00D
+    return
+  )
+  (func (export "i32.umax") (type $t)
+    i32.const 0xffffffff
+    return
+  )
 --
   (type $t (func (result i32)))
   (export "i32.test" (func $__fresh_0))
-  (func $__fresh_0 (type $t) (return (i32.const 0x0bAdD00D)))
+  (func $__fresh_0 (type $t)
+    i32.const 0x0bAdD00D
+    return
+  )
   (export "i32.umax" (func $__fresh_1))
-  (func $__fresh_1 (type $t) (return (i32.const 0xffffffff)))
+  (func $__fresh_1 (type $t)
+    i32.const 0xffffffff
+    return
+  )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
@@ -76,14 +94,18 @@ assert_preprocess_module_fields <<'--', <<'--'
     (export "i32.test2")
     (export "i32.test3")
     (type $t)
-    (return (i32.const 0x0bAdD00D))
+    i32.const 0x0bAdD00D
+    return
   )
 --
   (type $t (func (result i32)))
   (export "i32.test1" (func $__fresh_0))
   (export "i32.test2" (func $__fresh_0))
   (export "i32.test3" (func $__fresh_0))
-  (func $__fresh_0 (type $t) (return (i32.const 0x0bAdD00D)))
+  (func $__fresh_0 (type $t)
+    i32.const 0x0bAdD00D
+    return
+  )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
@@ -145,26 +167,28 @@ assert_preprocess <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (result i32)))
   (func (type $t) (local i32 f64 funcref)
-    (return (i32.const 0x0bAdD00D))
+    i32.const 0x0bAdD00D
+    return
   )
 --
   (type $t (func (result i32)))
   (func (type $t) (local i32) (local f64) (local funcref)
-    (return (i32.const 0x0bAdD00D))
+    i32.const 0x0bAdD00D
+    return
   )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result i64) (result i32)))
   (func (type $t) (param i32 i64) (result i64 i32)
-    (i64.const 1)
-    (i32.const 2)
+    i64.const 1
+    i32.const 2
   )
 --
   (type $t (func (param i32) (param i64) (result i64) (result i32)))
   (func (type $t) (param i32) (param i64) (result i64) (result i32)
-    (i64.const 1)
-    (i32.const 2)
+    i64.const 1
+    i32.const 2
   )
 --
 
@@ -186,19 +210,19 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func))
   (type $t2 (func (param i32) (param i32) (result i32) (result i32)))
   (func (type $t1)
-    (block (type $t2) (param i32 i32) (result i32 i32)
-      (i32.add)
-      (i32.const 1)
-    )
+    block (type $t2) (param i32 i32) (result i32 i32)
+      i32.add
+      i32.const 1
+    end
   )
 --
   (type $t1 (func))
   (type $t2 (func (param i32) (param i32) (result i32) (result i32)))
   (func (type $t1)
-    (block (type $t2) (param i32) (param i32) (result i32) (result i32)
-      (i32.add)
-      (i32.const 1)
-    )
+    block (type $t2) (param i32) (param i32) (result i32) (result i32)
+      i32.add
+      i32.const 1
+    end
   )
 --
 
@@ -209,10 +233,9 @@ assert_preprocess_module_fields <<'--', <<'--'
     (result f32) (result f64) (result i32))
   )
   (func (type $t1)
-    (call_indirect (type $t2)
+    call_indirect (type $t2)
       (param i64) (param) (param f64 i32 i64)
       (result f32 f64) (result i32)
-    )
   )
 --
   (type $t1 (func))
@@ -221,10 +244,9 @@ assert_preprocess_module_fields <<'--', <<'--'
     (result f32) (result f64) (result i32))
   )
   (func (type $t1)
-    (call_indirect (type $t2)
+    call_indirect (type $t2)
       (param i64) (param f64) (param i32) (param i64)
       (result f32) (result f64) (result i32)
-    )
   )
 --
 
@@ -238,7 +260,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t)
     (offset
-      (call_indirect (type $t1) (param i32 i64) (result f32 f64))
+      call_indirect (type $t1) (param i32 i64) (result f32 f64)
     )
     funcref (item ref.func $f)
   )
@@ -246,7 +268,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t)
     (offset
-      (call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64))
+      call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64)
     )
     funcref (item ref.func $f)
   )
@@ -255,12 +277,12 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (type $t1) (param i32 i64) (result f32 f64)))
+    (item call_indirect (type $t1) (param i32 i64) (result f32 f64))
   )
 --
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64)))
+    (item call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64))
   )
 --
 
@@ -352,7 +374,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (data (memory $m)
     (offset
-      (call_indirect (type $t) (param i32 i64) (result f32 f64))
+      call_indirect (type $t) (param i32 i64) (result f32 f64)
     )
     "hello" "world"
   )
@@ -360,7 +382,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (data (memory $m)
     (offset
-      (call_indirect (type $t) (param i32) (param i64) (result f32) (result f64))
+      call_indirect (type $t) (param i32) (param i64) (result f32) (result f64)
     )
     "hello" "world"
   )
@@ -388,12 +410,12 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (global $g i32
-    (call_indirect (type $t) (param i32 i64) (result f32 f64))
+    call_indirect (type $t) (param i32 i64) (result f32 f64)
   )
 --
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (global $g i32
-    (call_indirect (type $t) (param i32) (param i64) (result f32) (result f64))
+    call_indirect (type $t) (param i32) (param i64) (result f32) (result f64)
   )
 --
 
@@ -408,13 +430,19 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i32) (param i32) (result i32)))
   (func (type $t)
-    (select (result i32 i32) (local.get 0) (local.get 1) (local.get 2))
+    local.get 0
+    local.get 1
+    local.get 2
+    select (result i32 i32)
   )
   (type (func (result i32) (result i32)))
 --
   (type $t (func (param i32) (param i32) (param i32) (result i32)))
   (func (type $t)
-    (select (result i32) (result i32) (local.get 0) (local.get 1) (local.get 2))
+    local.get 0
+    local.get 1
+    local.get 2
+    select (result i32) (result i32)
   )
   (type (func (result i32) (result i32)))
 --
@@ -422,13 +450,23 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i32) (param i32) (result i32)))
   (func (type $t)
-    (select (result i32 i32) (local.get 0) (local.get 1) (local.get 2) (i32.const 1) (i32.add))
+    local.get 0
+    local.get 1
+    local.get 2
+    i32.const 1
+    i32.add
+    select (result i32 i32)
   )
   (type (func (result i32) (result i32)))
 --
   (type $t (func (param i32) (param i32) (param i32) (result i32)))
   (func (type $t)
-    (select (result i32) (result i32) (local.get 0) (local.get 1) (local.get 2) (i32.const 1) (i32.add))
+    local.get 0
+    local.get 1
+    local.get 2
+    i32.const 1
+    i32.add
+    select (result i32) (result i32)
   )
   (type (func (result i32) (result i32)))
 --
@@ -460,41 +498,45 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func))
   (func (type $t)
-    (block)
+    block
+    end
   )
 --
   (type $t (func))
   (func (type $t)
-    (block)
-  )
---
-
-assert_preprocess_module_fields <<'--', <<'--'
-  (type $t (func))
-  (func (type $t)
-    (block (result))
-  )
---
-  (type $t (func))
-  (func (type $t)
-    (block)
+    block
+    end
   )
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func))
   (func (type $t)
-    (block (result i64)
-      (i64.const 1)
-    )
+    block (result)
+    end
+  )
+--
+  (type $t (func))
+  (func (type $t)
+    block
+    end
+  )
+--
+
+assert_preprocess_module_fields <<'--', <<'--'
+  (type $t (func))
+  (func (type $t)
+    block (result i64)
+      i64.const 1
+    end
   )
   (type (func (result i64)))
 --
   (type $t (func))
   (func (type $t)
-    (block (result i64)
-      (i64.const 1)
-    )
+    block (result i64)
+      i64.const 1
+    end
   )
   (type (func (result i64)))
 --
@@ -502,17 +544,17 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func))
   (func (type $t)
-    (block (param) (result i64)
-      (i64.const 1)
-    )
+    block (param) (result i64)
+      i64.const 1
+    end
   )
   (type (func (result i64)))
 --
   (type $t (func))
   (func (type $t)
-    (block (result i64)
-      (i64.const 1)
-    )
+    block (result i64)
+      i64.const 1
+    end
   )
   (type (func (result i64)))
 --
@@ -537,25 +579,25 @@ assert_preprocess_module_fields <<'--', <<'--'
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param i32) (result i64)))
 --
   (func (type 0) (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param i32) (result i64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param f32) (result f64)))
   (type (func (param i32) (result i64)))
 --
   (func (type 1) (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param f32) (result f64)))
   (type (func (param i32) (result i64)))
@@ -594,12 +636,12 @@ assert_preprocess_module_fields <<'--', <<'--'
 
 assert_preprocess_module_fields <<'--', <<'--'
   (global $g i32
-    (call_indirect (param i32) (result f32))
+    call_indirect (param i32) (result f32)
   )
   (type (func (param i32) (result f32)))
 --
   (global $g i32
-    (call_indirect (type 0) (param i32) (result f32))
+    call_indirect (type 0) (param i32) (result f32)
   )
   (type (func (param i32) (result f32)))
 --
@@ -607,7 +649,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (elem (table $t)
     (offset
-      (call_indirect (param i32) (result f32))
+      call_indirect (param i32) (result f32)
     )
     funcref (item ref.func $f)
   )
@@ -615,7 +657,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
   (elem (table $t)
     (offset
-      (call_indirect (type 0) (param i32) (result f32))
+      call_indirect (type 0) (param i32) (result f32)
     )
     funcref (item ref.func $f)
   )
@@ -625,7 +667,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (data (memory $m)
     (offset
-      (call_indirect (param i32) (result f32))
+      call_indirect (param i32) (result f32)
     )
     "hello" "world"
   )
@@ -633,7 +675,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
   (data (memory $m)
     (offset
-      (call_indirect (type 0) (param i32) (result f32))
+      call_indirect (type 0) (param i32) (result f32)
     )
     "hello" "world"
   )
@@ -643,19 +685,19 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func))
   (func (type $t)
-    (block (param i32 i64)
-      (drop)
-      (drop)
-    )
+    block (param i32 i64)
+      drop
+      drop
+    end
   )
   (type (func (param i32) (param i64)))
 --
   (type $t (func))
   (func (type $t)
-    (block (type 1) (param i32) (param i64)
-      (drop)
-      (drop)
-    )
+    block (type 1) (param i32) (param i64)
+      drop
+      drop
+    end
   )
   (type (func (param i32) (param i64)))
 --
@@ -663,114 +705,114 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func))
   (func (type $t)
-    (block (param i32) (result i64)
-      (drop)
-      (i64.const 1)
-    )
+    block (param i32) (result i64)
+      drop
+      i64.const 1
+    end
   )
   (type (func (param i32) (result i64)))
 --
   (type $t (func))
   (func (type $t)
-    (block (type 1) (param i32) (result i64)
-      (drop)
-      (i64.const 1)
-    )
+    block (type 1) (param i32) (result i64)
+      drop
+      i64.const 1
+    end
   )
   (type (func (param i32) (result i64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (param i32) (result f32)))
+    (item call_indirect (param i32) (result f32))
   )
   (type (func (param i32) (result f32)))
 --
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (type 0) (param i32) (result f32)))
+    (item call_indirect (type 0) (param i32) (result f32))
   )
   (type (func (param i32) (result f32)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (table $t funcref
-    (elem (item (call_indirect (param i32) (result f32))))
+    (elem (item call_indirect (param i32) (result f32)))
   )
   (type (func (param i32) (result f32)))
 --
   (table $t 1 1 funcref)
   (elem (table $t) (offset i32.const 0) funcref
-    (item (call_indirect (type 0) (param i32) (result f32)))
+    (item call_indirect (type 0) (param i32) (result f32))
   )
   (type (func (param i32) (result f32)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param $x i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param i32) (result i64)))
 --
   (func (type 0) (param $x i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param i32) (result i64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param $x i32) (result i64)))
 --
   (func (type 0) (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param $x i32) (result i64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param $x i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param $y i32) (result i64)))
 --
   (func (type 0) (param $x i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param $y i32) (result i64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
 --
   (func (type 0) (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (type (func (param i32) (result i64)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (func (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (func (param i64) (result i32)
-    (i32.const 2)
+    i32.const 2
   )
   (func (param i32) (result i64)
-    (i64.const 3)
+    i64.const 3
   )
 --
   (func (type 0) (param i32) (result i64)
-    (i64.const 1)
+    i64.const 1
   )
   (func (type 1) (param i64) (result i32)
-    (i32.const 2)
+    i32.const 2
   )
   (func (type 0) (param i32) (result i64)
-    (i64.const 3)
+    i64.const 3
   )
   (type (func (param i32) (result i64)))
   (type (func (param i64) (result i32)))

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -233,7 +233,7 @@ assert_preprocess_module_fields <<'--', <<'--'
     (result f32) (result f64) (result i32))
   )
   (func (type $t1)
-    call_indirect (type $t2)
+    call_indirect 0 (type $t2)
       (param i64) (param) (param f64 i32 i64)
       (result f32 f64) (result i32)
   )
@@ -244,7 +244,7 @@ assert_preprocess_module_fields <<'--', <<'--'
     (result f32) (result f64) (result i32))
   )
   (func (type $t1)
-    call_indirect (type $t2)
+    call_indirect 0 (type $t2)
       (param i64) (param f64) (param i32) (param i64)
       (result f32) (result f64) (result i32)
   )
@@ -260,7 +260,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t)
     (offset
-      call_indirect (type $t1) (param i32 i64) (result f32 f64)
+      call_indirect 0 (type $t1) (param i32 i64) (result f32 f64)
     )
     funcref (item ref.func $f)
   )
@@ -268,7 +268,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t)
     (offset
-      call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64)
+      call_indirect 0 (type $t1) (param i32) (param i64) (result f32) (result f64)
     )
     funcref (item ref.func $f)
   )
@@ -277,12 +277,12 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t) (offset i32.const 0) funcref
-    (item call_indirect (type $t1) (param i32 i64) (result f32 f64))
+    (item call_indirect 0 (type $t1) (param i32 i64) (result f32 f64))
   )
 --
   (type $t1 (func (param i32) (param i64) (result f32) (result f64)))
   (elem (table $t) (offset i32.const 0) funcref
-    (item call_indirect (type $t1) (param i32) (param i64) (result f32) (result f64))
+    (item call_indirect 0 (type $t1) (param i32) (param i64) (result f32) (result f64))
   )
 --
 
@@ -374,7 +374,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (data (memory $m)
     (offset
-      call_indirect (type $t) (param i32 i64) (result f32 f64)
+      call_indirect 0 (type $t) (param i32 i64) (result f32 f64)
     )
     "hello" "world"
   )
@@ -382,7 +382,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (data (memory $m)
     (offset
-      call_indirect (type $t) (param i32) (param i64) (result f32) (result f64)
+      call_indirect 0 (type $t) (param i32) (param i64) (result f32) (result f64)
     )
     "hello" "world"
   )
@@ -410,12 +410,12 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (global $g i32
-    call_indirect (type $t) (param i32 i64) (result f32 f64)
+    call_indirect 0 (type $t) (param i32 i64) (result f32 f64)
   )
 --
   (type $t (func (param i32) (param i64) (result f32) (result f64)))
   (global $g i32
-    call_indirect (type $t) (param i32) (param i64) (result f32) (result f64)
+    call_indirect 0 (type $t) (param i32) (param i64) (result f32) (result f64)
   )
 --
 
@@ -563,7 +563,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (result i32)))
   (type $t2 (func (param i32) (param i64) (result f32) (result f64)))
   (func (type $t1)
-    call_indirect (type $t2) (param i32 i64) (result f32 f64)
+    call_indirect 0 (type $t2) (param i32 i64) (result f32 f64)
     i32.const 1
     i32.add
   )
@@ -571,7 +571,7 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type $t1 (func (param i32) (result i32)))
   (type $t2 (func (param i32) (param i64) (result f32) (result f64)))
   (func (type $t1)
-    call_indirect (type $t2) (param i32) (param i64) (result f32) (result f64)
+    call_indirect 0 (type $t2) (param i32) (param i64) (result f32) (result f64)
     i32.const 1
     i32.add
   )
@@ -636,12 +636,12 @@ assert_preprocess_module_fields <<'--', <<'--'
 
 assert_preprocess_module_fields <<'--', <<'--'
   (global $g i32
-    call_indirect (param i32) (result f32)
+    call_indirect 0 (param i32) (result f32)
   )
   (type (func (param i32) (result f32)))
 --
   (global $g i32
-    call_indirect (type 0) (param i32) (result f32)
+    call_indirect 0 (type 0) (param i32) (result f32)
   )
   (type (func (param i32) (result f32)))
 --
@@ -649,7 +649,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (elem (table $t)
     (offset
-      call_indirect (param i32) (result f32)
+      call_indirect 0 (param i32) (result f32)
     )
     funcref (item ref.func $f)
   )
@@ -657,7 +657,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
   (elem (table $t)
     (offset
-      call_indirect (type 0) (param i32) (result f32)
+      call_indirect 0 (type 0) (param i32) (result f32)
     )
     funcref (item ref.func $f)
   )
@@ -667,7 +667,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 assert_preprocess_module_fields <<'--', <<'--'
   (data (memory $m)
     (offset
-      call_indirect (param i32) (result f32)
+      call_indirect 0 (param i32) (result f32)
     )
     "hello" "world"
   )
@@ -675,7 +675,7 @@ assert_preprocess_module_fields <<'--', <<'--'
 --
   (data (memory $m)
     (offset
-      call_indirect (type 0) (param i32) (result f32)
+      call_indirect 0 (type 0) (param i32) (result f32)
     )
     "hello" "world"
   )
@@ -724,25 +724,25 @@ assert_preprocess_module_fields <<'--', <<'--'
 
 assert_preprocess_module_fields <<'--', <<'--'
   (elem (table $t) (offset i32.const 0) funcref
-    (item call_indirect (param i32) (result f32))
+    (item call_indirect 0 (param i32) (result f32))
   )
   (type (func (param i32) (result f32)))
 --
   (elem (table $t) (offset i32.const 0) funcref
-    (item call_indirect (type 0) (param i32) (result f32))
+    (item call_indirect 0 (type 0) (param i32) (result f32))
   )
   (type (func (param i32) (result f32)))
 --
 
 assert_preprocess_module_fields <<'--', <<'--'
   (table $t funcref
-    (elem (item call_indirect (param i32) (result f32)))
+    (elem (item call_indirect 0 (param i32) (result f32)))
   )
   (type (func (param i32) (result f32)))
 --
   (table $t 1 1 funcref)
   (elem (table $t) (offset i32.const 0) funcref
-    (item call_indirect (type 0) (param i32) (result f32))
+    (item call_indirect 0 (type 0) (param i32) (result f32))
   )
   (type (func (param i32) (result f32)))
 --


### PR DESCRIPTION
Despite #12, the preprocessor, parser and interpreter (and their tests) were still a little messy and inconsistent. This PR cleans them up to fix many minor annoyances in preparation for implementing instruction abbreviations.

The problems addressed are mostly related to naming and code organisation. The largest change is that all of the preprocessor tests have been updated to no longer depend upon the remaining instruction abbreviations (i.e. folded instructions and missing `call_index` index) which we intend to desugar.