### PR TITLE
Read complete instructions in AST parser

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -894,7 +894,12 @@ module Wasminna
     end
 
     def read_plain_instruction_immediates(keyword:)
-      []
+      case keyword
+      in 'call_indirect'
+        [*read_indexes, *read_typeuse]
+      else
+        []
+      end
     end
 
     def read_typeuse
@@ -909,6 +914,13 @@ module Wasminna
       repeatedly do
         raise StopIteration unless can_read_list?(starting_with: kind)
         read_list
+      end
+    end
+
+    def read_indexes
+      repeatedly do
+        raise StopIteration unless can_read_index?
+        read_index
       end
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -855,11 +855,17 @@ module Wasminna
 
     def read_instruction
       case peek
+      in [*]
+        read_folded_instruction
       in 'block' | 'loop' | 'if'
         read_structured_instruction
       else
         [read]
       end
+    end
+
+    def read_folded_instruction
+      [read_list]
     end
 
     def read_structured_instruction

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -899,6 +899,8 @@ module Wasminna
         [*read_indexes, *read_typeuse]
       in 'select'
         read_declarations(kind: 'result')
+      in 'table.get' | 'table.set' | 'table.size' | 'table.grow' | 'table.fill' | 'table.copy' | 'table.init' | 'br_table'
+        read_indexes
       else
         []
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -868,9 +868,9 @@ module Wasminna
 
     def read_structured_instruction
       [
-        read,
+        read, *read_optional_id,
         *read_instructions(until: 'end'),
-        read
+        read, *read_optional_id
       ]
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -903,6 +903,8 @@ module Wasminna
         read_indexes
       in 'br' | 'br_if' | 'call' | 'ref.null' | 'ref.func' | 'local.get' | 'local.set' | 'local.tee' | 'global.get' | 'global.set' | 'elem.drop' | 'memory.init' | 'data.drop' | %r{\A[fi](?:32|64)\.const\z}
         [read]
+      in %r{\A[fi](?:32|64)\.(?:load|store)}
+        [*(read if peek in %r{\Aoffset=}), *(read if peek in %r{\Aalign=})]
       else
         []
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -860,7 +860,7 @@ module Wasminna
       in 'block' | 'loop' | 'if'
         read_structured_instruction
       else
-        [read]
+        read_plain_instruction
       end
     end
 
@@ -884,6 +884,10 @@ module Wasminna
           read, *read_optional_id
         ]
       end
+    end
+
+    def read_plain_instruction
+      [read]
     end
 
     def read_typeuse

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -867,11 +867,21 @@ module Wasminna
     end
 
     def read_structured_instruction
-      [
-        read, *read_optional_id, *read_typeuse,
-        *read_instructions(until: 'end'),
-        read, *read_optional_id
-      ]
+      case peek
+      in 'block' | 'loop'
+        [
+          read, *read_optional_id, *read_typeuse,
+          *read_instructions(until: 'end'),
+          read, *read_optional_id
+        ]
+      in 'if'
+        [
+          read, *read_optional_id, *read_typeuse,
+          *read_instructions(until: %r{\A(?:end|else)\z}),
+          *([read, *read_instructions(until: 'end')] if peek in 'else'),
+          read, *read_optional_id
+        ]
+      end
     end
 
     def read_typeuse

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -901,6 +901,8 @@ module Wasminna
         read_declarations(kind: 'result')
       in 'table.get' | 'table.set' | 'table.size' | 'table.grow' | 'table.fill' | 'table.copy' | 'table.init' | 'br_table'
         read_indexes
+      in 'br' | 'br_if' | 'call' | 'ref.null' | 'ref.func' | 'local.get' | 'local.set' | 'local.tee' | 'global.get' | 'global.set' | 'elem.drop' | 'memory.init' | 'data.drop' | %r{\A[fi](?:32|64)\.const\z}
+        [read]
       else
         []
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -868,10 +868,25 @@ module Wasminna
 
     def read_structured_instruction
       [
-        read, *read_optional_id,
+        read, *read_optional_id, *read_typeuse,
         *read_instructions(until: 'end'),
         read, *read_optional_id
       ]
+    end
+
+    def read_typeuse
+      [
+        *([read_list] if can_read_list?(starting_with: 'type')),
+        *read_declarations(kind: 'param'),
+        *read_declarations(kind: 'result')
+      ]
+    end
+
+    def read_declarations(kind:)
+      repeatedly do
+        raise StopIteration unless can_read_list?(starting_with: kind)
+        read_list
+      end
     end
 
     def unsigned(signed, bits:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -847,10 +847,8 @@ module Wasminna
     def read_instructions(**kwargs, &)
       return read_list(from: read_instructions(**kwargs), &) if block_given?
 
-      kwargs => { until: terminator }
-
       repeatedly do
-        raise StopIteration if peek in ^terminator
+        raise StopIteration if peek in 'end' | 'else'
         read_instruction
       end.flatten(1)
     end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -897,6 +897,8 @@ module Wasminna
       case keyword
       in 'call_indirect'
         [*read_indexes, *read_typeuse]
+      in 'select'
+        read_declarations(kind: 'result')
       else
         []
       end

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -887,7 +887,14 @@ module Wasminna
     end
 
     def read_plain_instruction
-      [read]
+      [
+        keyword = read,
+        *read_plain_instruction_immediates(keyword:)
+      ]
+    end
+
+    def read_plain_instruction_immediates(keyword:)
+      []
     end
 
     def read_typeuse


### PR DESCRIPTION
The AST parser uses the #read_instructions method to read multiple instructions when parsing a [structured instruction](https://webassembly.github.io/spec/core/text/instructions.html#control-instructions), e.g. the body of a `loop` or the consequent of an `if`. However, #read_instructions doesn’t have any knowledge of the structure of WebAssembly instructions beyond the fact that structured instructions (`block`, `loop` and `if`) are terminated by `end`, so it mainly works by reading individual atoms with the misleadingly-named #read_instruction method and concatenating them indiscriminately.

This crude approach suffices for the parser because it’s able to defer the real work to #parse_instructions, which does know more about where individual instructions begin and end. But we’d like to share #read_instructions with the preprocessor so that it can desugar some instruction-specific abbreviations, and the preprocessor doesn’t have access to the more intelligent parsing machinery, so we need #read_instructions itself to be smarter.

This PR enriches the implementation of #read_instruction by giving it just enough knowledge of instruction syntax to be able to read a single complete instruction at a time. This doesn’t meaningfully change the functionality of the AST parser but does make its implementation clearer and less hacky. Most importantly it also makes the instruction-reading methods far more useful for the preprocessor, and in subsequent work we’ll extract them and use them when desugaring instruction abbreviations.