### PR TITLE
Read complete instructions in preprocessor

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -9,6 +9,7 @@ module Wasminna
     include Helpers::Mask
     include Helpers::ReadFromSExpression
     include Helpers::ReadIndex
+    include Helpers::ReadInstructions
     include Helpers::ReadOptionalId
     include Helpers::StringValue
 
@@ -841,94 +842,6 @@ module Wasminna
         TableCopy.new(destination_index:, source_index:)
       in 'ref.is_null'
         RefIsNull.new
-      end
-    end
-
-    def read_instructions(&)
-      return read_list(from: read_instructions, &) if block_given?
-
-      repeatedly do
-        raise StopIteration if peek in 'end' | 'else'
-        read_instruction
-      end.flatten(1)
-    end
-
-    def read_instruction
-      case peek
-      in [*]
-        read_folded_instruction
-      in 'block' | 'loop' | 'if'
-        read_structured_instruction
-      else
-        read_plain_instruction
-      end
-    end
-
-    def read_folded_instruction
-      [read_list]
-    end
-
-    def read_structured_instruction
-      case peek
-      in 'block' | 'loop'
-        [
-          read, *read_optional_id, *read_typeuse,
-          *read_instructions,
-          read, *read_optional_id
-        ]
-      in 'if'
-        [
-          read, *read_optional_id, *read_typeuse,
-          *read_instructions,
-          *([read, *read_instructions] if peek in 'else'),
-          read, *read_optional_id
-        ]
-      end
-    end
-
-    def read_plain_instruction
-      [
-        keyword = read,
-        *read_plain_instruction_immediates(keyword:)
-      ]
-    end
-
-    def read_plain_instruction_immediates(keyword:)
-      case keyword
-      in 'call_indirect'
-        [*read_indexes, *read_typeuse]
-      in 'select'
-        read_declarations(kind: 'result')
-      in 'table.get' | 'table.set' | 'table.size' | 'table.grow' | 'table.fill' | 'table.copy' | 'table.init' | 'br_table'
-        read_indexes
-      in 'br' | 'br_if' | 'call' | 'ref.null' | 'ref.func' | 'local.get' | 'local.set' | 'local.tee' | 'global.get' | 'global.set' | 'elem.drop' | 'memory.init' | 'data.drop' | %r{\A[fi](?:32|64)\.const\z}
-        [read]
-      in %r{\A[fi](?:32|64)\.(?:load|store)}
-        [*(read if peek in %r{\Aoffset=}), *(read if peek in %r{\Aalign=})]
-      else
-        []
-      end
-    end
-
-    def read_typeuse
-      [
-        *([read_list] if can_read_list?(starting_with: 'type')),
-        *read_declarations(kind: 'param'),
-        *read_declarations(kind: 'result')
-      ]
-    end
-
-    def read_declarations(kind:)
-      repeatedly do
-        raise StopIteration unless can_read_list?(starting_with: kind)
-        read_list
-      end
-    end
-
-    def read_indexes
-      repeatedly do
-        raise StopIteration unless can_read_index?
-        read_index
       end
     end
 

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -192,7 +192,9 @@ module Wasminna
         ]
       end
 
-      def read_declarations(kind:)
+      def read_declarations(kind:, &)
+        return read_list(from: read_declarations(kind:), &) if block_given?
+
         repeatedly do
           raise StopIteration unless can_read_list?(starting_with: kind)
           read_list

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -125,6 +125,13 @@ module Wasminna
         end.flatten(1)
       end
 
+      def read_folded_instructions
+        repeatedly do
+          raise StopIteration if can_read_list?(starting_with: 'then')
+          read_folded_instruction
+        end.flatten(1)
+      end
+
       def read_instruction
         case peek
         in [*]

--- a/lib/wasminna/helpers.rb
+++ b/lib/wasminna/helpers.rb
@@ -158,7 +158,9 @@ module Wasminna
         end
       end
 
-      def read_plain_instruction
+      def read_plain_instruction(&)
+        return read_list(from: read_plain_instruction, &) if block_given?
+
         [
           keyword = read,
           *read_plain_instruction_immediates(keyword:)

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -391,9 +391,10 @@ module Wasminna
 
     def process_plain_instruction
       read_plain_instruction do
-        case peek
+        read => keyword
+
+        case keyword
         in 'call_indirect'
-          read => 'call_indirect'
           read_index => index if can_read_index?
           typeuse = process_typeuse
 
@@ -401,14 +402,12 @@ module Wasminna
             ['call_indirect', *index, *typeuse.call(type_definitions)]
           end
         in 'select'
-          read => 'select'
           results = process_results
 
           after_all_fields do
             ['select', *results]
           end
         else
-          read => keyword
           immediates = repeatedly { read }
 
           after_all_fields do

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -373,9 +373,11 @@ module Wasminna
     end
 
     def process_folded_instruction
-      read_list { process_instructions }.then do |result|
-        after_all_fields do |type_definitions|
-          [result.call(type_definitions)]
+      read_list do
+        process_instructions.then do |result|
+          after_all_fields do |type_definitions|
+            [result.call(type_definitions)]
+          end
         end
       end
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -390,9 +390,9 @@ module Wasminna
     end
 
     def process_plain_instruction
-      case peek
-      in 'call_indirect'
-        read_plain_instruction do
+      read_plain_instruction do
+        case peek
+        in 'call_indirect'
           read => 'call_indirect'
           read_index => index if can_read_index?
           typeuse = process_typeuse
@@ -400,18 +400,14 @@ module Wasminna
           after_all_fields do |type_definitions|
             ['call_indirect', *index, *typeuse.call(type_definitions)]
           end
-        end
-      in 'select'
-        read_plain_instruction do
+        in 'select'
           read => 'select'
           results = process_results
 
           after_all_fields do
             ['select', *results]
           end
-        end
-      else
-        read_plain_instruction do
+        else
           read => keyword
           immediates = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -5,6 +5,7 @@ module Wasminna
   class Preprocessor
     include Helpers::ReadFromSExpression
     include Helpers::ReadIndex
+    include Helpers::ReadInstructions
     include Helpers::ReadOptionalId
     include Helpers::SizeOf
     include Helpers::StringValue
@@ -406,9 +407,12 @@ module Wasminna
           ['select', *results]
         end
       else
-        read.then do |result|
+        read_plain_instruction do
+          read => keyword
+          immediates = repeatedly { read }
+
           after_all_fields do
-            [result]
+            [keyword, *immediates]
           end
         end
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -389,6 +389,24 @@ module Wasminna
               ]
             ]
           end
+        in 'if'
+          read => 'if'
+          read_optional_id => label
+          blocktype = process_typeuse
+          condition = read_list(from: read_folded_instructions) { process_instructions }
+          consequent = read_list(starting_with: 'then') { process_instructions }
+          alternative = read_list(starting_with: 'else') { process_instructions } if can_read_list?(starting_with: 'else')
+
+          after_all_fields do |type_definitions|
+            [
+              [
+                'if', *label, *blocktype.call(type_definitions),
+                *condition.call(type_definitions),
+                ['then', *consequent.call(type_definitions)],
+                *([['else', *alternative.call(type_definitions)]] if alternative)
+              ]
+            ]
+          end
         else
           process_instructions.then do |result|
             after_all_fields do |type_definitions|

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -374,9 +374,26 @@ module Wasminna
 
     def process_folded_instruction
       read_list do
-        process_instructions.then do |result|
+        case peek
+        in 'block' | 'loop'
+          read => 'block' | 'loop' => keyword
+          read_optional_id => label
+          blocktype = process_typeuse
+          body = process_instructions
+
           after_all_fields do |type_definitions|
-            [result.call(type_definitions)]
+            [
+              [
+                keyword, *label, *blocktype.call(type_definitions),
+                *body.call(type_definitions)
+              ]
+            ]
+          end
+        else
+          process_instructions.then do |result|
+            after_all_fields do |type_definitions|
+              [result.call(type_definitions)]
+            end
           end
         end
       end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -356,19 +356,21 @@ module Wasminna
     end
 
     def process_instructions
-      repeatedly do
-        case peek
-        in [*]
-          process_folded_instruction
-        in 'block' | 'loop' | 'if'
-          process_structured_instruction
-        else
-          process_plain_instruction
-        end
-      end.then do |results|
+      repeatedly { process_instruction }.then do |results|
         after_all_fields do |type_definitions|
           results.flat_map { _1.call(type_definitions) }
         end
+      end
+    end
+
+    def process_instruction
+      case peek
+      in [*]
+        process_folded_instruction
+      in 'block' | 'loop' | 'if'
+        process_structured_instruction
+      else
+        process_plain_instruction
       end
     end
 
@@ -476,10 +478,6 @@ module Wasminna
       else
         read_list(from: blocktype) { process_typeuse }
       end
-    end
-
-    def process_instruction
-      process_instructions # TODO only process one instruction
     end
 
     def process_type_definition

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -392,19 +392,23 @@ module Wasminna
     def process_plain_instruction
       case peek
       in 'call_indirect'
-        read => 'call_indirect'
-        read_index => index if can_read_index?
-        typeuse = process_typeuse
+        read_plain_instruction do
+          read => 'call_indirect'
+          read_index => index if can_read_index?
+          typeuse = process_typeuse
 
-        after_all_fields do |type_definitions|
-          ['call_indirect', *index, *typeuse.call(type_definitions)]
+          after_all_fields do |type_definitions|
+            ['call_indirect', *index, *typeuse.call(type_definitions)]
+          end
         end
       in 'select'
-        read => 'select'
-        results = process_results
+        read_plain_instruction do
+          read => 'select'
+          results = process_results
 
-        after_all_fields do
-          ['select', *results]
+          after_all_fields do
+            ['select', *results]
+          end
         end
       else
         read_plain_instruction do

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -337,21 +337,22 @@ module Wasminna
     end
 
     def expand_anonymous_declarations(kind:)
-      repeatedly do
-        raise StopIteration unless can_read_list?(starting_with: kind)
-        read_list(starting_with: kind) do
-          read_optional_id => id
-          if id.nil?
-            repeatedly do
+      read_declarations(kind:) do
+        repeatedly do
+          read_list(starting_with: kind) do
+            read_optional_id => id
+            if id.nil?
+              repeatedly do
+                read => type
+                [kind, type]
+              end
+            else
               read => type
-              [kind, type]
+              [[kind, id, type]]
             end
-          else
-            read => type
-            [[kind, id, type]]
           end
-        end
-      end.flatten(1)
+        end.flatten(1)
+      end
     end
 
     def process_instructions


### PR DESCRIPTION
As established in #18, the AST parser now has the ability to read complete instructions. In this PR we extract and reuse the parser’s #read_instructions, #read_instruction and related methods to give the preprocessor the ability to preprocess entire instructions by reading their structures explicitly.

This approach replaces various hacks which didn’t really understand instruction structure but incidentally worked for all of the abbreviations already implemented. Consequently, the #process_instruction method now really does process a single instruction instead of delegating to #process_instructions to process as many as possible, which is important for the correctness of the `offset` and `item` abbreviations in [element](https://webassembly.github.io/spec/core/text/modules.html#id7) and [data](https://webassembly.github.io/spec/core/text/modules.html#id8) segments.

Now that the preprocessor is correctly traversing the detailed structure of each kind of instruction, we’ll be able to desugar all of the remaining abbreviations in subsequent work.