### PR TITLE
Desugar instruction abbreviations

### DIFF
--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -528,12 +528,8 @@ module Wasminna
 
     def parse_instructions(context:)
       repeatedly do
-        if can_read_list?
-          parse_folded_instruction(context:)
-        else
-          [parse_instruction(context:)]
-        end
-      end.flatten(1)
+        parse_instruction(context:)
+      end
     end
 
     def parse_instruction(context:)
@@ -545,17 +541,6 @@ module Wasminna
       else
         parse_normal_instruction(context:)
       end
-    end
-
-    def parse_folded_instruction(context:)
-      read_list do
-        parse_folded_plain_instruction(context:)
-      end
-    end
-
-    def parse_folded_plain_instruction(context:)
-      parse_instructions(context:) => [first, *rest]
-      [*rest, first]
     end
 
     def parse_numeric_instruction

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -741,12 +741,7 @@ module Wasminna
 
         BrTable.new(target_indexes:, default_index:)
       in 'call_indirect'
-        table_index =
-          if can_read_index?
-            parse_index(context.tables)
-          else
-            0
-          end
+        table_index = parse_index(context.tables)
         parse_typeuse(context:) => [type_index, parameter_names]
         raise unless parameter_names.all?(&:nil?)
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -550,7 +550,7 @@ module Wasminna
     def parse_folded_instruction(context:)
       read_list do
         case peek
-        in 'block' | 'loop' | 'if'
+        in 'block' | 'loop'
           parse_folded_structured_instruction(context:)
         else
           parse_folded_plain_instruction(context:)
@@ -571,25 +571,6 @@ module Wasminna
       in 'loop'
         body = parse_instructions(context:)
         [Loop.new(type:, body:)]
-      in 'if'
-        condition =
-          repeatedly do
-            raise StopIteration if can_read_list?(starting_with: 'then')
-            parse_folded_instruction(context:)
-          end.flatten(1)
-        consequent =
-          read_list(starting_with: 'then') do
-            parse_instructions(context:)
-          end
-        alternative =
-          if can_read_list?(starting_with: 'else')
-            read_list(starting_with: 'else') do
-              parse_instructions(context:)
-            end
-          else
-            []
-          end
-        [*condition, If.new(type:, consequent:, alternative:)]
       end
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -549,28 +549,7 @@ module Wasminna
 
     def parse_folded_instruction(context:)
       read_list do
-        case peek
-        in 'block' | 'loop'
-          parse_folded_structured_instruction(context:)
-        else
-          parse_folded_plain_instruction(context:)
-        end
-      end
-    end
-
-    def parse_folded_structured_instruction(context:)
-      read => keyword
-      read_optional_id => label
-      type = parse_blocktype(context:)
-      context = Context.new(labels: [label]) + context
-
-      case keyword
-      in 'block'
-        body = parse_instructions(context:)
-        [Block.new(type:, body:)]
-      in 'loop'
-        body = parse_instructions(context:)
-        [Loop.new(type:, body:)]
+        parse_folded_plain_instruction(context:)
       end
     end
 

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -767,12 +767,8 @@ module Wasminna
 
         TableInit.new(table_index:, element_index:)
       in 'table.copy'
-        destination_index, source_index =
-          if can_read_index?
-            [parse_index(context.tables), parse_index(context.tables)]
-          else
-            [0, 0]
-          end
+        destination_index = parse_index(context.tables)
+        source_index = parse_index(context.tables)
 
         TableCopy.new(destination_index:, source_index:)
       in 'ref.is_null'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -754,16 +754,8 @@ module Wasminna
         index = parse_index(context.functions)
         RefFunc.new(index:)
       in 'table.init'
-        read_index => index
-        if can_read_index?
-          table_index =
-            read_list(from: [index]) { parse_index(context.tables) }
-          element_index = parse_index(context.elem)
-        else
-          table_index = 0
-          element_index =
-            read_list(from: [index]) { parse_index(context.elem) }
-        end
+        table_index = parse_index(context.tables)
+        element_index = parse_index(context.elem)
 
         TableInit.new(table_index:, element_index:)
       in 'table.copy'

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -648,10 +648,8 @@ module Wasminna
         Loop.new(type:, body:)
       in 'if'
         consequent = read_instructions { parse_instructions(context:) }
-        if peek in 'else'
-          read => 'else'
-          read_optional_id => nil | ^label
-        end
+        read => 'else'
+        read_optional_id => nil | ^label
         alternative = read_instructions { parse_instructions(context:) }
 
         If.new(type:, consequent:, alternative:)

--- a/lib/wasminna/ast_parser.rb
+++ b/lib/wasminna/ast_parser.rb
@@ -717,12 +717,7 @@ module Wasminna
           'elem.drop' => ElemDrop
         }.fetch(keyword).new(index:)
       in 'table.get' | 'table.set' | 'table.fill' | 'table.grow' | 'table.size' => keyword
-        index =
-          if can_read_index?
-            parse_index(context.tables)
-          else
-            0
-          end
+        index = parse_index(context.tables)
 
         {
           'table.get' => TableGet,

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -468,11 +468,11 @@ module Wasminna
 
         case keyword
         in 'call_indirect'
-          read_index => index if can_read_index?
+          index = can_read_index? ? read_index : '0'
           typeuse = process_typeuse
 
           after_all_fields do |type_definitions|
-            ['call_indirect', *index, *typeuse.call(type_definitions)]
+            ['call_indirect', index, *typeuse.call(type_definitions)]
           end
         in 'select'
           results = process_results

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -404,8 +404,6 @@ module Wasminna
             *body,
             'end'
           ]
-
-        read_list(from: expanded) { process_instructions }
       in 'if'
         condition = read_folded_instructions
         consequent = read_list(starting_with: 'then')
@@ -420,9 +418,9 @@ module Wasminna
             *alternative,
             'end'
           ]
-
-        read_list(from: expanded) { process_instructions }
       end
+
+      read_list(from: expanded) { process_instructions }
     end
 
     def process_structured_instruction

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -480,6 +480,12 @@ module Wasminna
           after_all_fields do
             ['select', *results]
           end
+        in 'table.get' | 'table.set' | 'table.size' | 'table.grow' | 'table.fill'
+          index = read_index if can_read_index?
+
+          after_all_fields do
+            [keyword, *index]
+          end
         else
           immediates = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -481,10 +481,10 @@ module Wasminna
             ['select', *results]
           end
         in 'table.get' | 'table.set' | 'table.size' | 'table.grow' | 'table.fill'
-          index = read_index if can_read_index?
+          index = can_read_index? ? read_index : '0'
 
           after_all_fields do
-            [keyword, *index]
+            [keyword, index]
           end
         else
           immediates = repeatedly { read }

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -430,16 +430,6 @@ module Wasminna
       case keyword
       in 'block' | 'loop'
         body = read_instructions { process_instructions }
-        read => 'end'
-        read_optional_id => end_label
-
-        after_all_fields do |type_definitions|
-          [
-            keyword, *label, *blocktype.call(type_definitions),
-            *body.call(type_definitions),
-            'end', *end_label
-          ]
-        end
       in 'if'
         consequent = read_instructions { process_instructions }
         if peek in 'else'
@@ -455,16 +445,17 @@ module Wasminna
               *alternative.call(type_definitions)
             ]
           end
-        read => 'end'
-        read_optional_id => end_label
+      end
 
-        after_all_fields do |type_definitions|
-          [
-            keyword, *label, *blocktype.call(type_definitions),
-            *body.call(type_definitions),
-            'end', *end_label
-          ]
-        end
+      read => 'end'
+      read_optional_id => end_label
+
+      after_all_fields do |type_definitions|
+        [
+          keyword, *label, *blocktype.call(type_definitions),
+          *body.call(type_definitions),
+          'end', *end_label
+        ]
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -447,15 +447,21 @@ module Wasminna
           read_optional_id => else_label
         end
         alternative = read_instructions { process_instructions }
+        body =
+          after_all_fields do |type_definitions|
+            [
+              *consequent.call(type_definitions),
+              *else_keyword, *else_label,
+              *alternative.call(type_definitions)
+            ]
+          end
         read => 'end'
         read_optional_id => end_label
 
         after_all_fields do |type_definitions|
           [
             keyword, *label, *blocktype.call(type_definitions),
-            *consequent.call(type_definitions),
-            *else_keyword, *else_label,
-            *alternative.call(type_definitions),
+            *body.call(type_definitions),
             'end', *end_label
           ]
         end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -494,7 +494,7 @@ module Wasminna
           end
         in 'table.init'
           index = read_index
-          indexes = can_read_index? ? [index, read_index] : [index]
+          indexes = can_read_index? ? [index, read_index] : ['0', index]
 
           after_all_fields do
             ['table.init', *indexes]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -487,7 +487,7 @@ module Wasminna
             [keyword, index]
           end
         in 'table.copy'
-          indexes = [read_index, read_index] if can_read_index?
+          indexes = can_read_index? ? [read_index, read_index] : ['0', '0']
 
           after_all_fields do
             ['table.copy', *indexes]

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -380,11 +380,7 @@ module Wasminna
         in 'block' | 'loop' | 'if'
           expand_folded_structured_instruction
         else
-          process_instructions.then do |result|
-            after_all_fields do |type_definitions|
-              [result.call(type_definitions)]
-            end
-          end
+          expand_folded_plain_instruction
         end
       end
     end
@@ -418,6 +414,14 @@ module Wasminna
             'end'
           ]
         end
+
+      read_list(from: expanded) { process_instructions }
+    end
+
+    def expand_folded_plain_instruction
+      plain_instruction = read_plain_instruction
+      folded_instructions = read_folded_instructions
+      expanded = [*folded_instructions, *plain_instruction]
 
       read_list(from: expanded) { process_instructions }
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -394,17 +394,17 @@ module Wasminna
       in 'block' | 'loop'
         read => 'block' | 'loop' => keyword
         read_optional_id => label
-        blocktype = process_typeuse
-        body = process_instructions
+        blocktype = read_typeuse
+        body = read_instructions
 
-        after_all_fields do |type_definitions|
+        expanded =
           [
-            [
-              keyword, *label, *blocktype.call(type_definitions),
-              *body.call(type_definitions)
-            ]
+            keyword, *label, *blocktype,
+            *body,
+            'end'
           ]
-        end
+
+        read_list(from: expanded) { process_instructions }
       in 'if'
         read => 'if'
         read_optional_id => label

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -390,11 +390,12 @@ module Wasminna
     end
 
     def process_folded_structured_instruction
-      case peek
+      read => 'block' | 'loop' | 'if' => keyword
+      read_optional_id => label
+      blocktype = read_typeuse
+
+      case keyword
       in 'block' | 'loop'
-        read => 'block' | 'loop' => keyword
-        read_optional_id => label
-        blocktype = read_typeuse
         body = read_instructions
 
         expanded =
@@ -406,9 +407,6 @@ module Wasminna
 
         read_list(from: expanded) { process_instructions }
       in 'if'
-        read => 'if'
-        read_optional_id => label
-        blocktype = read_typeuse
         condition = read_folded_instructions
         consequent = read_list(starting_with: 'then')
         alternative = read_list(starting_with: 'else') if can_read_list?(starting_with: 'else')

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -492,6 +492,13 @@ module Wasminna
           after_all_fields do
             ['table.copy', *indexes]
           end
+        in 'table.init'
+          index = read_index
+          indexes = can_read_index? ? [index, read_index] : [index]
+
+          after_all_fields do
+            ['table.init', *indexes]
+          end
         else
           immediates = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -394,22 +394,21 @@ module Wasminna
       read_optional_id => label
       blocktype = read_typeuse
 
-      case keyword
-      in 'block' | 'loop'
-        body = read_instructions
+      expanded =
+        case keyword
+        in 'block' | 'loop'
+          body = read_instructions
 
-        expanded =
           [
             keyword, *label, *blocktype,
             *body,
             'end'
           ]
-      in 'if'
-        condition = read_folded_instructions
-        consequent = read_list(starting_with: 'then')
-        alternative = read_list(starting_with: 'else') if can_read_list?(starting_with: 'else')
+        in 'if'
+          condition = read_folded_instructions
+          consequent = read_list(starting_with: 'then')
+          alternative = read_list(starting_with: 'else') if can_read_list?(starting_with: 'else')
 
-        expanded =
           [
             *condition,
             'if', *label, *blocktype,
@@ -418,7 +417,7 @@ module Wasminna
             *alternative,
             'end'
           ]
-      end
+        end
 
       read_list(from: expanded) { process_instructions }
     end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -486,6 +486,12 @@ module Wasminna
           after_all_fields do
             [keyword, index]
           end
+        in 'table.copy'
+          indexes = [read_index, read_index] if can_read_index?
+
+          after_all_fields do
+            ['table.copy', *indexes]
+          end
         else
           immediates = repeatedly { read }
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -426,18 +426,18 @@ module Wasminna
       read => 'block' | 'loop' | 'if' => keyword
       read_optional_id => label
       blocktype = process_blocktype
+      body =
+        case keyword
+        in 'block' | 'loop'
+          read_instructions { process_instructions }
+        in 'if'
+          consequent = read_instructions { process_instructions }
+          if peek in 'else'
+            read => else_keyword
+            read_optional_id => else_label
+          end
+          alternative = read_instructions { process_instructions }
 
-      case keyword
-      in 'block' | 'loop'
-        body = read_instructions { process_instructions }
-      in 'if'
-        consequent = read_instructions { process_instructions }
-        if peek in 'else'
-          read => else_keyword
-          read_optional_id => else_label
-        end
-        alternative = read_instructions { process_instructions }
-        body =
           after_all_fields do |type_definitions|
             [
               *consequent.call(type_definitions),
@@ -445,8 +445,7 @@ module Wasminna
               *alternative.call(type_definitions)
             ]
           end
-      end
-
+        end
       read => 'end'
       read_optional_id => end_label
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -408,21 +408,22 @@ module Wasminna
       in 'if'
         read => 'if'
         read_optional_id => label
-        blocktype = process_typeuse
-        condition = read_list(from: read_folded_instructions) { process_instructions }
-        consequent = read_list(starting_with: 'then') { process_instructions }
-        alternative = read_list(starting_with: 'else') { process_instructions } if can_read_list?(starting_with: 'else')
+        blocktype = read_typeuse
+        condition = read_folded_instructions
+        consequent = read_list(starting_with: 'then')
+        alternative = read_list(starting_with: 'else') if can_read_list?(starting_with: 'else')
 
-        after_all_fields do |type_definitions|
+        expanded =
           [
-            [
-              'if', *label, *blocktype.call(type_definitions),
-              *condition.call(type_definitions),
-              ['then', *consequent.call(type_definitions)],
-              *([['else', *alternative.call(type_definitions)]] if alternative)
-            ]
+            *condition,
+            'if', *label, *blocktype,
+            *consequent,
+            'else',
+            *alternative,
+            'end'
           ]
-        end
+
+        read_list(from: expanded) { process_instructions }
       end
     end
 

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -378,7 +378,7 @@ module Wasminna
       read_list do
         case peek
         in 'block' | 'loop' | 'if'
-          process_folded_structured_instruction
+          expand_folded_structured_instruction
         else
           process_instructions.then do |result|
             after_all_fields do |type_definitions|
@@ -389,7 +389,7 @@ module Wasminna
       end
     end
 
-    def process_folded_structured_instruction
+    def expand_folded_structured_instruction
       read => 'block' | 'loop' | 'if' => keyword
       read_optional_id => label
       blocktype = read_typeuse

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -437,7 +437,7 @@ module Wasminna
         in 'if'
           consequent = read_instructions { process_instructions }
           if peek in 'else'
-            read => else_keyword
+            read => 'else'
             read_optional_id => else_label
           end
           alternative = read_instructions { process_instructions }
@@ -445,7 +445,7 @@ module Wasminna
           after_all_fields do |type_definitions|
             [
               *consequent.call(type_definitions),
-              *else_keyword, *else_label,
+              'else', *else_label,
               *alternative.call(type_definitions)
             ]
           end

--- a/lib/wasminna/preprocessor.rb
+++ b/lib/wasminna/preprocessor.rb
@@ -366,7 +366,7 @@ module Wasminna
     def process_instruction
       case peek
       in [*]
-        process_folded_instruction
+        expand_folded_instruction
       in 'block' | 'loop' | 'if'
         process_structured_instruction
       else
@@ -374,7 +374,7 @@ module Wasminna
       end
     end
 
-    def process_folded_instruction
+    def expand_folded_instruction
       read_list do
         case peek
         in 'block' | 'loop' | 'if'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -948,12 +948,14 @@ assert_preprocess_instructions <<'--', <<'--'
   table.size
   table.grow
   table.fill
+  table.copy
 --
   table.get 0
   table.set 0
   table.size 0
   table.grow 0
   table.fill 0
+  table.copy 0 0
 --
 
 BEGIN {

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -949,6 +949,7 @@ assert_preprocess_instructions <<'--', <<'--'
   table.grow
   table.fill
   table.copy
+  table.init 42
 --
   table.get 0
   table.set 0
@@ -956,6 +957,7 @@ assert_preprocess_instructions <<'--', <<'--'
   table.grow 0
   table.fill 0
   table.copy 0 0
+  table.init 0 42
 --
 
 BEGIN {

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -936,6 +936,12 @@ assert_preprocess_instructions <<'--', <<'--'
   select (result i32)
 --
 
+assert_preprocess_instructions <<'--', <<'--'
+  call_indirect (type $t)
+--
+  call_indirect 0 (type $t)
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -818,6 +818,45 @@ assert_preprocess_module_fields <<'--', <<'--'
   (type (func (param i64) (result i32)))
 --
 
+assert_preprocess_instructions <<'--', <<'--'
+  (if $label (result i32)
+    (then)
+    (else)
+  )
+--
+  if $label (result i32)
+  else
+  end
+--
+
+assert_preprocess_instructions <<'--', <<'--'
+  (if $label (result i32)
+    (then)
+  )
+--
+  if $label (result i32)
+  else
+  end
+--
+
+assert_preprocess_instructions <<'--', <<'--'
+  (if $label1 (result i32)
+    (if $label2 (result i32)
+      (then)
+      (else)
+    )
+    (then)
+    (else)
+  )
+--
+  if $label2 (result i32)
+  else
+  end
+  if $label1 (result i32)
+  else
+  end
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -850,6 +850,12 @@ BEGIN {
   def assert_preprocess_module_fields(input, expected)
     assert_preprocess "(module #{input})", "(module #{expected})"
   end
+
+  def assert_preprocess_instructions(input, expected)
+    assert_preprocess_module_fields \
+      "(type (func)) (func (type 0) #{input})",
+      "(type (func)) (func (type 0) #{expected})"
+  end
 }
 
 END {

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -942,6 +942,20 @@ assert_preprocess_instructions <<'--', <<'--'
   call_indirect 0 (type $t)
 --
 
+assert_preprocess_instructions <<'--', <<'--'
+  table.get
+  table.set
+  table.size
+  table.grow
+  table.fill
+--
+  table.get 0
+  table.set 0
+  table.size 0
+  table.grow 0
+  table.fill 0
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -903,6 +903,39 @@ assert_preprocess_instructions <<'--', <<'--'
   end
 --
 
+assert_preprocess_instructions <<'--', <<'--'
+  (if $label (result i32) (i32.const 0)
+    (then i32.const 1)
+    (else i32.const 2)
+  )
+--
+  i32.const 0
+  if $label (result i32)
+    i32.const 1
+  else
+    i32.const 2
+  end
+--
+
+assert_preprocess_instructions <<'--', <<'--'
+  (i32.mul (i32.add (local.get $x) (i32.const 2)) (i32.const 3))
+--
+  local.get $x
+  i32.const 2
+  i32.add
+  i32.const 3
+  i32.mul
+--
+
+assert_preprocess_instructions <<'--', <<'--'
+  (select (result i32) (local.get 0) (local.get 1) (local.get 2))
+--
+  local.get 0
+  local.get 1
+  local.get 2
+  select (result i32)
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -960,6 +960,12 @@ assert_preprocess_instructions <<'--', <<'--'
   table.init 0 42
 --
 
+assert_preprocess_instructions <<'--', <<'--'
+  if i32.const 0 nop end
+--
+  if i32.const 0 nop else end
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -857,6 +857,52 @@ assert_preprocess_instructions <<'--', <<'--'
   end
 --
 
+assert_preprocess_instructions <<'--', <<'--'
+  (block $label (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add
+  )
+--
+  block $label (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add
+  end
+--
+
+assert_preprocess_instructions <<'--', <<'--'
+  (loop $label (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add
+  )
+--
+  loop $label (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add
+  end
+--
+
+assert_preprocess_instructions <<'--', <<'--'
+  (block $label1 (result i64)
+    (loop $label2 (result i32)
+      i32.const 1
+      i32.const 2
+      i32.add
+    )
+  )
+--
+  block $label1 (result i64)
+    loop $label2 (result i32)
+      i32.const 1
+      i32.const 2
+      i32.add
+    end
+  end
+--
+
 BEGIN {
   require 'wasminna/preprocessor'
   require 'wasminna/s_expression_parser'


### PR DESCRIPTION
The only abbreviations not yet desugared by the preprocessor are those relating to individual instructions: [folded instructions](https://webassembly.github.io/spec/core/text/instructions.html#text-foldedinstr) generally, optional `else` after `if`, and various optional immediate arguments to plain instructions.

This PR desugars the remaining abbreviations and removes support for them from the AST parser.